### PR TITLE
Configurable GraphQL body size limit

### DIFF
--- a/packages/graphql/src/getQuery.js
+++ b/packages/graphql/src/getQuery.js
@@ -6,7 +6,7 @@ const {json} = micro
 export default async function(request) {
   if (request.method === 'POST') {
     try {
-      return await json(request)
+      return await json(request, { limit: (process.env.MICRO_BODY_LIMIT || '1mb') })
     } catch (error) {
       console.error(error)
     }


### PR DESCRIPTION
This will use the environment variable 'MICRO_BODY_LIMIT' to set the body size limit, following the micro format, example: '10mb'.

Fixes #33