### PR TITLE
fix: allow passing through options to ApolloServer

### DIFF
--- a/packages/graphql/src/getApolloOptions/index.js
+++ b/packages/graphql/src/getApolloOptions/index.js
@@ -10,9 +10,9 @@ export default async function (options) {
     schema,
     formatError,
     useGraphiql: options.useGraphiql || true,
-    engine: options.engine,
     context: integrationContext => {
       return integrationContext.req._orionjsViewer
-    }
+    },
+    ...options
   }
 }


### PR DESCRIPTION
Required for customizing settings such as disabling the GraphQL playground.