### PR TITLE
remove priority + config intervals

### DIFF
--- a/packages/jobs/src/JobsCollection/schema.js
+++ b/packages/jobs/src/JobsCollection/schema.js
@@ -22,9 +22,5 @@ export default {
   result: {
     type: 'blackbox',
     optional: true
-  },
-  priority: {
-    type: Number,
-    optional: true
   }
 }

--- a/packages/jobs/src/daemon/JobsRepository.js
+++ b/packages/jobs/src/daemon/JobsRepository.js
@@ -35,7 +35,7 @@ class JobRepository {
         $set: {lockedAt: new Date()}
       },
       {
-        sort: {priority: 1, runAfter: 1}
+        sort: {runAfter: 1}
       }
     )
   }

--- a/packages/jobs/src/daemon/loop.js
+++ b/packages/jobs/src/daemon/loop.js
@@ -4,20 +4,24 @@ import createJobExecutor from './createJobExecutor'
 import {config} from '@orion-js/app'
 
 export default async function ({jobs, workers}) {
+  const {logger, jobs: jobsConfig} = config()
+  const defaultConfig = {
+    polling: 5000,
+    delay: 100,
+    ...jobsConfig
+  }
   const freeWorker = await getFreeWorker(workers)
 
   global.lastJobLoopDate = new Date()
   const jobData = await JobRepository.getJobAndLock()
   if (!jobData) {
-    return 1000
+    return defaultConfig.polling
   }
   if (jobData.lockedAt) {
-    const {logger} = config()
     logger.info('Resuming stalled job: ' + jobData.job)
   }
 
   const func = createJobExecutor({jobData, jobs})
   freeWorker.execute(func, jobData, jobs[jobData.job])
-
-  return 0
+  return defaultConfig.delay
 }

--- a/packages/jobs/src/initJobs/initRecurrentJob.js
+++ b/packages/jobs/src/initJobs/initRecurrentJob.js
@@ -27,8 +27,7 @@ export default async function (job) {
       {
         $set: {
           identifier: generateId(),
-          runAfter,
-          priority: job.priority
+          runAfter
         }
       }
     )

--- a/packages/jobs/src/job/getExecute.js
+++ b/packages/jobs/src/job/getExecute.js
@@ -5,6 +5,7 @@ export default function (job) {
   const {logger} = config()
   return async (params, jobData) => {
     try {
+      const startedAt = new Date()
       const result = {}
       try {
         params = job.type === 'recurrent' ? jobData : params
@@ -16,7 +17,7 @@ export default function (job) {
       }
 
       if (job.type === 'recurrent') {
-        const previousInfo = {...result, date: jobData.runAfter, endedAt: new Date()}
+        const previousInfo = {...result, date: startedAt, endedAt: new Date()}
 
         await JobsCollection.upsert(
           {job: job.identifier},
@@ -25,7 +26,6 @@ export default function (job) {
               lockedAt: null,
               identifier: generateId(),
               runAfter: await job.getNextRun(previousInfo),
-              priority: job.priority,
               ...(job.persistResults && !result.error && result.result
                 ? {result: result.result}
                 : {})

--- a/packages/jobs/src/job/index.js
+++ b/packages/jobs/src/job/index.js
@@ -2,7 +2,7 @@ import runJob from './runJob'
 import cancelExecution from './cancelExecution'
 import getExecute from './getExecute'
 
-export default function ({name, type, run, getNextRun, runEvery, persistResult, priority}) {
+export default function ({name, type, run, getNextRun, runEvery, persistResult}) {
   const job = (...args) => runJob.apply(job, args)
 
   job.runJob = (...args) => runJob.apply(job, args)
@@ -13,7 +13,6 @@ export default function ({name, type, run, getNextRun, runEvery, persistResult, 
   job.runEvery = runEvery
   job.cancelExecution = cancelExecution
   job.persistResult = persistResult
-  job.priority = priority
 
   return job
 }

--- a/packages/jobs/src/job/runJob.js
+++ b/packages/jobs/src/job/runJob.js
@@ -2,19 +2,19 @@ import JobsCollection from '../JobsCollection'
 import {generateId} from '@orion-js/app'
 
 export default async function (params, {identifier, waitToRun} = {}) {
-  const getIdentifier = maxRetries =>
+  const getJobId = maxRetries =>
     new Promise((resolve, reject) => {
       if (this.identifier) return resolve(this.identifier)
       if (maxRetries <= 0)
         return reject(new Error('Job must be initialized in "start()" to be able to run'))
       setTimeout(() => {
-        resolve(getIdentifier(maxRetries - 1))
+        resolve(getJobId(maxRetries - 1))
       }, 1000)
     })
 
-  await getIdentifier(5)
+  await getJobId(5)
 
-  identifier = identifier || generateId()
+  const eventId = identifier || generateId()
 
   if (this.type !== 'event') {
     throw new Error('You can only call event jobs, not ' + this.type)
@@ -27,11 +27,10 @@ export default async function (params, {identifier, waitToRun} = {}) {
   await JobsCollection.await()
   await JobsCollection.insert({
     job: this.identifier,
-    identifier,
+    identifier: eventId,
     params,
-    runAfter,
-    priority: this.priority
+    runAfter
   })
 
-  return identifier
+  return eventId
 }


### PR DESCRIPTION
- Se eliminan prioridades ya que la query de obtención de jobs empeora su rendimiento considerablemente.
- Se cambia el "runEvery" para que tome la hora de ejecución y no el "runAfter". Esto ocacionaba un "bug" en que si un job se demoraba más que su "runEvery" lentamente el "runAfter" empezaba a quedar "en el pasado" y nunca alcanzándolo. 
- Se puede modificar por config el polling cuando no hay jobs y el delay entre jobs ejecutados. (Limita la cantidad de jobs que se pueden ejecutar por segundo) Delay 100 => 10 por segundo. 


