### PR TITLE
options parameter on aggregate method

### DIFF
--- a/packages/app/src/collection/getMethods/aggregate.js
+++ b/packages/app/src/collection/getMethods/aggregate.js
@@ -1,4 +1,4 @@
 export default ({rawCollection}) =>
-  function aggregate(pipeline) {
-    return rawCollection.aggregate(pipeline)
+  function aggregate(pipeline, options = {}) {
+    return rawCollection.aggregate(pipeline, options)
   }

--- a/packages/app/src/collection/getMethods/aggregate.test.js
+++ b/packages/app/src/collection/getMethods/aggregate.test.js
@@ -1,0 +1,30 @@
+import Collection from '../index'
+const {ReadPreference} = require('mongodb')
+import generateId from '../../helpers/generateId'
+
+it('ensuring the options are passed properly to the aggregate command', async () => {
+  const Tests = await new Collection({name: generateId()}).await()
+
+  const cursorDefault = await Tests.aggregate([
+    {
+      $match: {}
+    }
+  ])
+
+  expect(cursorDefault.operation.readPreference.mode).toBe(ReadPreference.PRIMARY)
+  expect(cursorDefault.options.readPreference.mode).toBe(ReadPreference.PRIMARY)
+
+  const cursorSecondary = await Tests.aggregate(
+    [
+      {
+        $match: {}
+      }
+    ],
+    {
+      readPreference: 'secondary'
+    }
+  )
+
+  expect(cursorSecondary.operation.readPreference.mode).toBe(ReadPreference.SECONDARY)
+  expect(cursorSecondary.options.readPreference.mode).toBe(ReadPreference.SECONDARY)
+})


### PR DESCRIPTION
Adding the 'options' parameter to the aggregate method of the collections, which will be passed to the mongodb raw collection. By default, the options parameter will be an empty object.