### PR TITLE
Pre-compute of paginatedResolvers' count during construction

### DIFF
--- a/packages/app/src/resolvers/paginatedResolver/index.js
+++ b/packages/app/src/resolvers/paginatedResolver/index.js
@@ -4,7 +4,7 @@ import getParams from './params'
 import setOptions from './setOptions'
 import getArgs from '../resolver/getResolver/getArgs'
 
-export default function({returns, collection, params, getCursor, ...otherOptions}) {
+export default function ({returns, collection, params, getCursor, ...otherOptions}) {
   const getPaginatedCursor = async (...args) => {
     if (getCursor) {
       return await getCursor(...args)
@@ -19,13 +19,17 @@ export default function({returns, collection, params, getCursor, ...otherOptions
       const {callParams: params, viewer} = getArgs(...args)
       const cursor = await getPaginatedCursor(...args)
 
+      /* counting the total number of elements of this cursor, so we make sure
+       that it is going to be computed only once */
+      const count = await cursor.count()
       const options = setOptions(params, cursor)
 
       return {
         cursor,
         params,
         viewer,
-        options
+        options,
+        count
       }
     },
     ...otherOptions


### PR DESCRIPTION
With this change, the count of the cursor is performed only once in the construction of paginatedResolver, and the totalCount, totalPages hasNextPage and hasPreviousPage resolvers will use that pre-computed value. This will reduce the amount of counts performed to the data base.