### PR TITLE
Fix [Jobs]: Allow creating single jobs with a disabled job queue

### DIFF
--- a/packages/jobs/globalConfig.json
+++ b/packages/jobs/globalConfig.json
@@ -1,1 +1,1 @@
-{"mongoUri":"mongodb://127.0.0.1:50987/"}
+{"mongoUri":"mongodb://127.0.0.1:51069/"}

--- a/packages/jobs/globalConfig.json
+++ b/packages/jobs/globalConfig.json
@@ -1,1 +1,1 @@
-{"mongoUri":"mongodb://127.0.0.1:51069/"}
+{"mongoUri":"mongodb://127.0.0.1:58732/"}

--- a/packages/jobs/globalConfig.json
+++ b/packages/jobs/globalConfig.json
@@ -1,1 +1,1 @@
-{"mongoUri":"mongodb://127.0.0.1:58732/"}
+{"mongoUri":"mongodb://127.0.0.1:50987/"}

--- a/packages/jobs/src/job/job.test.ts
+++ b/packages/jobs/src/job/job.test.ts
@@ -19,12 +19,6 @@ describe('job helper', () => {
           run: runMock
         })
       }
-
-      await init({
-        jobs: specs,
-        dbAddress: url,
-        namespace: 'job'
-      })
     })
 
     afterEach(async () => {
@@ -34,6 +28,12 @@ describe('job helper', () => {
     })
 
     it('retries the job 3 times before failing', async () => {
+      await init({
+        jobs: specs,
+        dbAddress: url,
+        namespace: 'job'
+      })
+
       const eventData = {
         example: true
       }
@@ -48,10 +48,34 @@ describe('job helper', () => {
     })
 
     it('can schedule a job in the future', async () => {
+      await init({
+        jobs: specs,
+        dbAddress: url,
+        namespace: 'job'
+      })
+
       const eventData = {
         example: true
       }
       await (specs as {eventJob: Job}).eventJob.schedule(eventData, 'in 1 day')
+
+      await new Promise(r => setTimeout(r, 500))
+
+      expect(runMock).toHaveBeenCalledTimes(0)
+    })
+
+    it('can schedule without explicitly starting agenda', async () => {
+      await init({
+        jobs: specs,
+        dbAddress: url,
+        namespace: 'job',
+        disabled: true
+      })
+
+      const eventData = {
+        example: true
+      }
+      await (specs as {eventJob: Job}).eventJob.schedule(eventData)
 
       await new Promise(r => setTimeout(r, 500))
 

--- a/packages/jobs/src/job/job.test.ts
+++ b/packages/jobs/src/job/job.test.ts
@@ -19,6 +19,12 @@ describe('job helper', () => {
           run: runMock
         })
       }
+
+      await init({
+        jobs: specs,
+        dbAddress: url,
+        namespace: 'job'
+      })
     })
 
     afterEach(async () => {
@@ -28,12 +34,6 @@ describe('job helper', () => {
     })
 
     it('retries the job 3 times before failing', async () => {
-      await init({
-        jobs: specs,
-        dbAddress: url,
-        namespace: 'job'
-      })
-
       const eventData = {
         example: true
       }
@@ -48,12 +48,6 @@ describe('job helper', () => {
     })
 
     it('can schedule a job in the future', async () => {
-      await init({
-        jobs: specs,
-        dbAddress: url,
-        namespace: 'job'
-      })
-
       const eventData = {
         example: true
       }
@@ -63,8 +57,21 @@ describe('job helper', () => {
 
       expect(runMock).toHaveBeenCalledTimes(0)
     })
+  })
 
+  describe('misc checks', () => {
     it('can schedule without explicitly starting agenda', async () => {
+      runMock = jest.fn(() => Promise.reject('some error'))
+      specs = {
+        eventJob: job({
+          type: 'single',
+          name: 'eventJob',
+          maxRetries: 3,
+          getNextRun: () => new Date(),
+          run: runMock
+        })
+      }
+
       await init({
         jobs: specs,
         dbAddress: url,
@@ -80,6 +87,8 @@ describe('job helper', () => {
       await new Promise(r => setTimeout(r, 500))
 
       expect(runMock).toHaveBeenCalledTimes(0)
+
+      await JobManager.getAgenda().close()
     })
   })
 })

--- a/packages/jobs/src/operations/init.ts
+++ b/packages/jobs/src/operations/init.ts
@@ -55,12 +55,12 @@ export async function init(opts: InitOptions) {
   })
 
   JobManager.init(agenda, {namespace})
-
-  if (disabled) {
-    console.log('Skipping jobs.start(). ORION_TEST env var or disabled option is set.')
-  } else {
-    await JobManager.start()
-  }
+  await JobManager.start()
 
   await initJobs(agenda, jobs, disabled)
+
+  if (disabled) {
+    console.log('Stopping jobs. ORION_TEST env var or disabled option is set.')
+    await JobManager.getAgenda().stop()
+  }
 }


### PR DESCRIPTION
This allows using separate machines for triggering and running jobs.