### PR TITLE
[jobs] Feat: additional options when triggering single jobs

### DIFF
--- a/packages/jobs/src/JobManager.ts
+++ b/packages/jobs/src/JobManager.ts
@@ -6,18 +6,25 @@ export class JobManagerContainer {
   private agenda: Agenda | void
   public state: 'started' | 'stopped' = 'stopped'
   public namespace = ''
+  public logger = console
 
-  public init(agenda: Agenda, {namespace = ''}: {namespace?: string} = {}) {
+  public init(
+    agenda: Agenda,
+    {namespace = '', logger = console}: {namespace?: string; logger?: typeof console} = {}
+  ) {
     if (this.agenda) {
       throw new JobsAlreadyInitializedError()
     }
     this.agenda = agenda
     this.namespace = namespace
+    this.logger = logger
   }
 
   public async start() {
     if (this.state === 'started') {
-      console.warn('jobs.start() called on an already started Job scheduler. Skipping operation...')
+      this.logger.warn(
+        'jobs.start() called on an already started Job scheduler. Skipping operation...'
+      )
       return
     }
     await this.getAgenda().start()
@@ -26,7 +33,9 @@ export class JobManagerContainer {
 
   public async stop() {
     if (this.state === 'stopped') {
-      console.warn('jobs.stop() called on an already stopped Job scheduler. Skipping operation...')
+      this.logger.warn(
+        'jobs.stop() called on an already stopped Job scheduler. Skipping operation...'
+      )
       return
     }
     await this.getAgenda().stop()

--- a/packages/jobs/src/collections/JobRetries.ts
+++ b/packages/jobs/src/collections/JobRetries.ts
@@ -1,6 +1,5 @@
 import {TypedModel, Prop} from '@orion-js/typed-model'
 import {createCollection} from '@orion-js/mongodb'
-import {} from '@orion-js/typed-model'
 
 @TypedModel()
 export class JobRetry {

--- a/packages/jobs/src/collections/JobUniquenessKeys.test.ts
+++ b/packages/jobs/src/collections/JobUniquenessKeys.test.ts
@@ -1,0 +1,5 @@
+import JobUniquenessKeys from './JobUniquenessKeys'
+
+it('should connect to the database correctly', async () => {
+  await JobUniquenessKeys.findOne()
+})

--- a/packages/jobs/src/collections/JobUniquenessKeys.ts
+++ b/packages/jobs/src/collections/JobUniquenessKeys.ts
@@ -1,0 +1,23 @@
+import {TypedModel, Prop} from '@orion-js/typed-model'
+import {createCollection} from '@orion-js/mongodb'
+
+@TypedModel()
+export class JobUniquenessKey {
+  @Prop()
+  key: string
+}
+
+export const JobUniquenessKeys = createCollection<JobUniquenessKey>({
+  name: 'orion_v3_jobs.uniqueness_keys',
+  model: JobUniquenessKey,
+  indexes: [
+    {
+      keys: {key: 1},
+      options: {
+        unique: true
+      }
+    }
+  ]
+})
+
+export default JobUniquenessKeys

--- a/packages/jobs/src/errors/JobIsNotUnique.ts
+++ b/packages/jobs/src/errors/JobIsNotUnique.ts
@@ -1,0 +1,5 @@
+export class JobIsNotUniqueError extends Error {
+  constructor(uniquenessKey: string) {
+    super(`Job with uniqueness key "${uniquenessKey}" already exists.`)
+  }
+}

--- a/packages/jobs/src/errors/index.ts
+++ b/packages/jobs/src/errors/index.ts
@@ -1,1 +1,4 @@
 export * from './JobScheduleRequired'
+export * from './JobsAlreadyInitialized'
+export * from './JobIsNotUnique'
+export * from './JobsNotInitialized'

--- a/packages/jobs/src/initJobs/index.ts
+++ b/packages/jobs/src/initJobs/index.ts
@@ -47,9 +47,9 @@ export default async function initJobs(agenda: Agenda, jobs: JobMap, disabled = 
       throw new JobScheduleRequiredError(jobName)
     }
 
-    // Event jobs
+    // Single jobs
     if (job.type === 'single') {
-      // Do nothing, event jobs are defined on call (see /job/index.ts)
+      // Do nothing, single jobs are defined on call (see /job/index.ts)
       return
     }
   })

--- a/packages/jobs/src/initJobs/initJobs.test.ts
+++ b/packages/jobs/src/initJobs/initJobs.test.ts
@@ -18,7 +18,7 @@ describe('initJobs', () => {
           }
         }),
 
-        eventJob: job({
+        singleJob: job({
           type: 'single',
           getNextRun: () => nextRun,
           run: () => {
@@ -48,26 +48,26 @@ describe('initJobs', () => {
       expect(jobs[0].attrs.nextRunAt).toEqual(nextRun)
     })
 
-    it('does not add event jobs to agenda before triggering them', async () => {
+    it('does not add single jobs to agenda before triggering them', async () => {
       const agenda: Agenda = JobManager.getAgenda()
 
-      const jobs = await agenda.jobs({name: 'initJobs.eventJob'})
+      const jobs = await agenda.jobs({name: 'initJobs.singleJob'})
       expect(jobs.length).toBe(0)
     })
 
-    it('adds event jobs to agenda after triggering them', async () => {
+    it('adds single jobs to agenda after triggering them', async () => {
       const agenda: Agenda = JobManager.getAgenda()
 
-      const eventData = {
+      const data = {
         example: true
       }
 
-      await (specs as {eventJob: Job}).eventJob.schedule(eventData)
-      const jobs = await agenda.jobs({name: 'initJobs.eventJob'})
+      await (specs as {singleJob: Job}).singleJob.schedule(data)
+      const jobs = await agenda.jobs({name: 'initJobs.singleJob'})
       expect(jobs.length).toBe(1)
       expect(jobs[0].attrs._id).toBeDefined()
       expect(jobs[0].attrs.nextRunAt).toEqual(nextRun)
-      expect(jobs[0].attrs.data).toEqual(eventData)
+      expect(jobs[0].attrs.data).toEqual(data)
     })
   })
 

--- a/packages/jobs/src/job/addMaxRetries.ts
+++ b/packages/jobs/src/job/addMaxRetries.ts
@@ -19,10 +19,8 @@ const addMaxRetries = (agenda: Agenda, job: JobDefinition, jobName: string): Pro
     const originalJobId = agendaJob.attrs.data?._parentJobId ?? agendaJob.attrs._id.toString()
 
     try {
-      await job.run(agendaJob.attrs.data, {
-        ...agendaJob,
-        timesExecuted: 1
-      })
+      const currProcessor = getProcessorFromJob(job)
+      await currProcessor(agendaJob)
     } catch (err) {
       let retry: JobRetry = await JobRetries.findOne({jobId: originalJobId})
 

--- a/packages/jobs/src/job/job.test.ts
+++ b/packages/jobs/src/job/job.test.ts
@@ -2,18 +2,19 @@ import {url} from '../test/setup'
 import {JobManager} from '../JobManager'
 import {Job} from '../types'
 import {init, job} from '..'
+import {JobIsNotUniqueError} from '../errors'
 
 describe('job helper', () => {
   let specs = {}
   let runMock
 
-  describe('max retries', () => {
+  describe('single job opts', () => {
     beforeEach(async () => {
-      runMock = jest.fn(() => Promise.reject('some error'))
+      runMock = jest.fn()
       specs = {
-        eventJob: job({
+        singleJob: job({
           type: 'single',
-          name: 'eventJob',
+          name: 'singleJob',
           maxRetries: 3,
           getNextRun: () => new Date(),
           run: runMock
@@ -23,21 +24,88 @@ describe('job helper', () => {
       await init({
         jobs: specs,
         dbAddress: url,
-        namespace: 'job'
+        namespace: 'job_opts',
+        disabled: true
       })
     })
 
     afterEach(async () => {
       await JobManager.stop()
-      await JobManager.getAgenda().close({force: true})
+      JobManager.clear()
+    })
+
+    describe('when checking for uniqueness', () => {
+      it('checks for uniqueness when required', async () => {
+        const data = {
+          example: true
+        }
+        await (specs as {singleJob: Job}).singleJob.schedule(data, {
+          uniqueness: {
+            key: 'constKey'
+          }
+        })
+
+        await expect(
+          (specs as {singleJob: Job}).singleJob.schedule(data, {
+            uniqueness: {
+              key: 'constKey'
+            }
+          })
+        ).rejects.toThrow(JobIsNotUniqueError)
+      })
+
+      it('ignores the error if the option is set', async () => {
+        const data = {
+          example: true
+        }
+        await (specs as {singleJob: Job}).singleJob.schedule(data, {
+          uniqueness: {
+            key: 'constKey'
+          }
+        })
+
+        await expect(
+          (specs as {singleJob: Job}).singleJob.schedule(data, {
+            uniqueness: {
+              key: 'constKey',
+              ignoreError: true
+            }
+          })
+        ).resolves.not.toThrow()
+      })
+    })
+  })
+
+  describe('job retrying', () => {
+    beforeEach(async () => {
+      runMock = jest.fn(() => Promise.reject('some error'))
+      specs = {
+        singleJob: job({
+          type: 'single',
+          name: 'singleJob',
+          maxRetries: 3,
+          getNextRun: () => new Date(),
+          run: runMock
+        })
+      }
+
+      await init({
+        jobs: specs,
+        dbAddress: url,
+        namespace: 'job_retry'
+      })
+    })
+
+    afterEach(async () => {
+      await JobManager.stop()
       JobManager.clear()
     })
 
     it('retries the job 3 times before failing', async () => {
-      const eventData = {
+      const data = {
         example: true
       }
-      await (specs as {eventJob: Job}).eventJob.schedule(eventData)
+      await (specs as {singleJob: Job}).singleJob.schedule(data)
 
       await new Promise(r => setTimeout(r, 500))
 
@@ -45,15 +113,22 @@ describe('job helper', () => {
       expect(runMock.mock.calls[0][0].example).toEqual(true)
       expect(runMock.mock.calls[1][0].example).toEqual(true)
       expect(runMock.mock.calls[2][0].example).toEqual(true)
+      expect(runMock.mock.calls[0][1].timesExecuted).toEqual(0)
+      expect(runMock.mock.calls[1][1].timesExecuted).toEqual(1)
+      expect(runMock.mock.calls[2][1].timesExecuted).toEqual(2)
     })
 
     it('can schedule a job in the future', async () => {
-      const eventData = {
+      const data = {
         example: true
       }
-      await (specs as {eventJob: Job}).eventJob.schedule(eventData, 'in 1 day')
+      await (specs as {singleJob: Job}).singleJob.schedule(data, {
+        runAt: 'in 500 milliseconds'
+      })
 
-      await new Promise(r => setTimeout(r, 500))
+      expect(runMock).toHaveBeenCalledTimes(0)
+
+      await new Promise(r => setTimeout(r, 1000))
 
       expect(runMock).toHaveBeenCalledTimes(0)
     })
@@ -63,9 +138,9 @@ describe('job helper', () => {
     it('can schedule without explicitly starting agenda', async () => {
       runMock = jest.fn(() => Promise.reject('some error'))
       specs = {
-        eventJob: job({
+        singleJob: job({
           type: 'single',
-          name: 'eventJob',
+          name: 'singleJob',
           maxRetries: 3,
           getNextRun: () => new Date(),
           run: runMock
@@ -75,20 +150,20 @@ describe('job helper', () => {
       await init({
         jobs: specs,
         dbAddress: url,
-        namespace: 'job',
+        namespace: 'job_misc',
         disabled: true
       })
 
-      const eventData = {
+      const data = {
         example: true
       }
-      await (specs as {eventJob: Job}).eventJob.schedule(eventData)
+      await (specs as {singleJob: Job}).singleJob.schedule(data)
 
       await new Promise(r => setTimeout(r, 500))
 
       expect(runMock).toHaveBeenCalledTimes(0)
 
-      await JobManager.getAgenda().close()
+      await JobManager.stop()
     })
   })
 })

--- a/packages/jobs/src/job/jobUniquenessCheck.ts
+++ b/packages/jobs/src/job/jobUniquenessCheck.ts
@@ -1,0 +1,34 @@
+import JobUniquenessKeys from '../collections/JobUniquenessKeys'
+import {JobIsNotUniqueError} from '../errors/JobIsNotUnique'
+
+/**
+ * Validates that the uniqueness key has not been used.
+ * If it was used, it will throw an error (unless ignoreUniquenessError is set to true).
+ * Inserts a key if it was not used.
+ * @param uniquenessKey The uniqueness key to validate.
+ * @param ignoreUniquenessError If true, will not throw an error if the uniqueness key has been used (will omit executing the job silently)
+ * @returns true if the uniqueness key has not been used, false if it has.
+ */
+export const jobUniquenessCheck = async (
+  uniquenessKey?: string,
+  ignoreUniquenessError = false
+): Promise<boolean> => {
+  if (!uniquenessKey) {
+    return true
+  }
+
+  const existingJob = await JobUniquenessKeys.findOne({key: uniquenessKey})
+  if (existingJob) {
+    if (ignoreUniquenessError) {
+      return false
+    }
+
+    throw new JobIsNotUniqueError(uniquenessKey)
+  }
+
+  await JobUniquenessKeys.insertOne({
+    key: uniquenessKey
+  })
+
+  return true
+}

--- a/packages/jobs/src/operations/init.ts
+++ b/packages/jobs/src/operations/init.ts
@@ -28,6 +28,11 @@ export interface InitOptions {
    * If set to true, will initialize jobs but won't start running them. Single jobs can still be scheduled so that they run in another machine.
    */
   disabled?: boolean
+
+  /**
+   * The logger. Defaults to console.
+   */
+  logger?: typeof console
 }
 
 export async function init(opts: InitOptions) {
@@ -37,7 +42,8 @@ export async function init(opts: InitOptions) {
     dbAddress = process.env.MONGO_URL,
     dbCollection = 'orion_v3_jobs',
     disabled = process.env.ORION_TEST ? true : false,
-    namespace = ''
+    namespace = '',
+    logger = console
   } = opts
 
   if (!dbAddress) {
@@ -54,13 +60,13 @@ export async function init(opts: InitOptions) {
     ...agendaConfig
   })
 
-  JobManager.init(agenda, {namespace})
+  JobManager.init(agenda, {namespace, logger})
   await JobManager.start()
 
   await initJobs(agenda, jobs, disabled)
 
   if (disabled) {
-    console.log('Stopping jobs. ORION_TEST env var or disabled option is set.')
+    logger.log('Stopping jobs. ORION_TEST env var or disabled option is set.')
     await JobManager.getAgenda().stop()
   }
 }

--- a/packages/jobs/src/types/job.ts
+++ b/packages/jobs/src/types/job.ts
@@ -77,10 +77,34 @@ export interface JobInfo extends AgendaJob {
 
 export type RunFunction = (data: any, job: JobInfo) => any
 
-export type ScheduleJobFunction = (
-  data?: object,
+export interface ScheduleJobOpts {
+  /**
+   * If included, will run the job at the specified Date. Can also be a human readable string (e.g. "in 5 minutes"). If not included, will use the JobDefinition.getNextRun(). If getNextRun is null, it will run immediately.
+   */
   runAt?: Date | string
-) => Promise<AgendaJob> | void
+
+  /**
+   * If included (and runAt is null), will run the job after that amount of milliseconds.
+   */
+  waitToRun?: number
+
+  /**
+   * In case deduplication is needed.
+   */
+  uniqueness?: {
+    /**
+     * The uniqueness key. If included, will tag the job with the given key on the first run. If a job with the same key is scheduled after the first run, an error will be thrown and the job won't be ran.
+     */
+    key: string
+
+    /**
+     * If set to true, instead of throwing an error when a job with the given key is not unique, the job will be omitted silently.
+     */
+    ignoreError?: boolean
+  }
+}
+
+export type ScheduleJobFunction = (data?: object, opts?: ScheduleJobOpts) => Promise<AgendaJob>
 export interface Job {
   /**
    * Internal use only.
@@ -94,3 +118,5 @@ export interface Job {
    */
   schedule: ScheduleJobFunction
 }
+
+export type PromiseProcessor = (job: AgendaJob) => void | Promise<void>


### PR DESCRIPTION
# Changelog

- Uniqueness options when triggering single jobs (to prevent duplication if desired)
- Adds error logs when a job fails