### PR TITLE
[resolvers] Fix: do not allow undefined params

### DIFF
--- a/packages/resolvers/src/resolver/index.test.ts
+++ b/packages/resolvers/src/resolver/index.test.ts
@@ -199,5 +199,5 @@ it('should allow calling resolver.resolve', async () => {
   })
 
   expect(await resolver.resolve({title: 'test'})).toBe('test')
-  expect(await modelResolver.resolve({title: 'test'})).toBe('test')
+  expect(await modelResolver.resolve({title: 'test'}, {})).toBe('test')
 })

--- a/packages/resolvers/src/resolver/types.ts
+++ b/packages/resolvers/src/resolver/types.ts
@@ -1,13 +1,13 @@
 import {OrionCache} from '@orion-js/cache'
 
 export type GlobalResolverResolve<ParamsType = any, ReturnType = any> = (
-  params?: ParamsType,
+  params: ParamsType,
   viewer?: any
 ) => Promise<ReturnType>
 
 export type ModelResolverResolve<ModelType = any, ParamsType = any, ReturnType = any> = (
   item: ModelType,
-  params?: ParamsType,
+  params: ParamsType,
   viewer?: any
 ) => Promise<ReturnType>
 


### PR DESCRIPTION
# Changelog

Forces `resolve.params` not to be undefined.