### PR TITLE
Hotfix: signature calculation error

### DIFF
--- a/packages/auth/src/getResolvers/getSession.ts
+++ b/packages/auth/src/getResolvers/getSession.ts
@@ -50,9 +50,8 @@ export default async function (req: express.Request) {
   const body = req.body
   const shaObj = new JSSHA('SHA-512', 'TEXT')
   shaObj.setHMACKey(session.secretKey, 'TEXT')
-  shaObj.update(nonce + body)
+  shaObj.update(nonce + JSON.stringify(body))
   const calculatedSignature = shaObj.getHMAC('HEX')
-
   if (signature !== calculatedSignature) {
     throw new Error('invalidSignature')
   }

--- a/packages/graphql/src/resolversSchemas/ResolverParams.ts
+++ b/packages/graphql/src/resolversSchemas/ResolverParams.ts
@@ -33,7 +33,7 @@ export default createModel({
     basicResultQuery: resolver({
       returns: String,
       resolve: async function ({resolver}: ResolverMetaParam) {
-        return await getBasicResultQuery({type: resolver.returns.getSchema()})
+        return await getBasicResultQuery({type: resolver.returns?.getSchema()})
       }
     })
   }

--- a/packages/http/src/viewer.ts
+++ b/packages/http/src/viewer.ts
@@ -7,7 +7,8 @@ export const getViewer = async (req: express.Request): Promise<any> => {
     const viewer = await global.getViewerRef(req)
     if (!viewer) return {}
     return viewer
-  } catch {
+  } catch (err) {
+    console.error('Orion HTTP Error: error getting viewer: ', err)
     return {}
   }
 }

--- a/packages/jobs/src/initJobs/initJobs.test.ts
+++ b/packages/jobs/src/initJobs/initJobs.test.ts
@@ -16,6 +16,13 @@ describe('initJobs', () => {
             // Do nothing
           }
         }),
+        runEveryJob: job({
+          type: 'recurrent',
+          runEvery: '1 millisecond',
+          run: () => {
+            // Do nothing
+          }
+        }),
 
         singleJob: job({
           type: 'single',
@@ -30,6 +37,7 @@ describe('initJobs', () => {
         jobs: specs,
         namespace: 'initJobs'
       })
+      await new Promise(r => setTimeout(r, 100))
     })
 
     afterEach(async () => {
@@ -44,6 +52,36 @@ describe('initJobs', () => {
       expect(jobs.length).toBe(1)
       expect(jobs[0].attrs._id).toBeDefined()
       expect(jobs[0].attrs.nextRunAt).toEqual(nextRun)
+    })
+
+    it('does not add duplicates on reinitialization', async () => {
+      await stop()
+      JobManager.clear()
+      await new Promise(r => setTimeout(r, 100))
+
+      await init({
+        jobs: specs,
+        namespace: 'initJobs'
+      })
+      const agenda: Agenda = JobManager.getAgenda()
+
+      const jobs: AgendaJob[] = await agenda.jobs({name: 'initJobs.recurrentJob'})
+      expect(jobs.length).toBe(1)
+    })
+
+    it('does not add duplicates on reinitialization for a runEvery job', async () => {
+      await stop()
+      JobManager.clear()
+      await new Promise(r => setTimeout(r, 100))
+
+      await init({
+        jobs: specs,
+        namespace: 'initJobs'
+      })
+      const agenda: Agenda = JobManager.getAgenda()
+
+      const jobs: AgendaJob[] = await agenda.jobs({name: 'initJobs.runEveryJob'})
+      expect(jobs.length).toBe(1)
     })
 
     it('does not add single jobs to agenda before triggering them', async () => {
@@ -69,27 +107,53 @@ describe('initJobs', () => {
     })
   })
 
-  it('calls the run function for a recurrent job', async () => {
-    const mock = jest.fn()
-    const specs = {
-      recurrentJob: job({
-        type: 'recurrent',
-        name: 'recurrentJob',
-        getNextRun: () => new Date(),
-        run: mock
-      })
-    }
+  describe('calling jobs', () => {
+    it('calls the run function for a recurrent job', async () => {
+      const mock = jest.fn()
+      const specs = {
+        recurrentJob: job({
+          type: 'recurrent',
+          name: 'recurrentJob',
+          getNextRun: () => new Date(Date.now() + 100),
+          run: mock
+        })
+      }
 
-    await init({
-      jobs: specs,
-      namespace: 'initJobs.recurrent'
+      await init({
+        jobs: specs,
+        namespace: 'initJobs.recurrent'
+      })
+
+      await new Promise(r => setTimeout(r, 500))
+
+      expect(mock).toHaveBeenCalled()
+
+      await stop()
+      JobManager.clear()
     })
 
-    await new Promise(r => setTimeout(r, 200))
+    it('calls the run function for a recurrent, runEvery job', async () => {
+      const mock = jest.fn()
+      const specs = {
+        recurrentJob: job({
+          type: 'recurrent',
+          name: 'recurrentJob',
+          runEvery: '100 milliseconds',
+          run: mock
+        })
+      }
 
-    expect(mock).toHaveBeenCalled()
+      await init({
+        jobs: specs,
+        namespace: 'initJobs.runEvery'
+      })
 
-    await stop()
-    JobManager.clear()
+      await new Promise(r => setTimeout(r, 500))
+
+      expect(mock).toHaveBeenCalled()
+
+      await stop()
+      JobManager.clear()
+    })
   })
 })

--- a/packages/jobs/src/job/index.ts
+++ b/packages/jobs/src/job/index.ts
@@ -15,8 +15,12 @@ export const job = (jobDefinition: JobDefinition): Job => {
   const nameRef = {name: null}
 
   const initializer = (jobKey: string): JobDefinition => {
-    const jobName = getJobName(nameRef.name ?? jobKey)
-    nameRef.name = jobName
+    let jobName = nameRef.name
+    if (!nameRef.name) {
+      jobName = getJobName(jobKey)
+      nameRef.name = jobName
+    }
+
     if (jobDefinition.type === 'recurrent') return jobDefinition // Recurrent jobs are defined during initJobs
 
     const agenda = JobManager.getAgenda()


### PR DESCRIPTION
# Changelog

- Fixes error where signature was being calculated for `nonce + body` as `1234123[object Object]` 
- Fixes a bug in jobs where it duplicated jobs on reinitialization