### PR TITLE
[mongodb] Feat: add modelItem.update method

### DIFF
--- a/packages/graphql/src/resolversSchemas/ResolverParams.ts
+++ b/packages/graphql/src/resolversSchemas/ResolverParams.ts
@@ -6,8 +6,12 @@ import {Resolver, resolver} from '@orion-js/resolvers'
 export interface ResolverMetaParam {
   resolver: {
     params: any
-    returns: Model
+    returns: Model | any
   }
+}
+
+const resolverReturnsIsModel = (returns: Model | any): returns is Model => {
+  return returns && returns.__isModel
 }
 
 export default createModel({
@@ -33,7 +37,9 @@ export default createModel({
     basicResultQuery: resolver({
       returns: String,
       resolve: async function ({resolver}: ResolverMetaParam) {
-        return await getBasicResultQuery({type: resolver.returns?.getSchema()})
+        return await getBasicResultQuery({
+          type: resolverReturnsIsModel(resolver.returns) ? resolver.returns.getSchema() : ''
+        })
       }
     })
   }

--- a/packages/models/src/createModel/initItem.ts
+++ b/packages/models/src/createModel/initItem.ts
@@ -9,7 +9,10 @@ interface InitItemOptions {
   resolvers: ModelResolversMap
 }
 
-export default function ({schema, resolvers, name}: InitItemOptions, item: any): any {
+export default function initItem<ModelClass = any>(
+  {schema, resolvers, name}: InitItemOptions,
+  item: ModelClass
+): ModelClass {
   if (isNil(item)) {
     return item
   }

--- a/packages/models/src/createModel/validation.test.ts
+++ b/packages/models/src/createModel/validation.test.ts
@@ -1,4 +1,5 @@
 import createModel from './index'
+import {resolver} from '@orion-js/resolvers'
 
 it('should validate a schema', async () => {
   const model = createModel({
@@ -43,4 +44,33 @@ it('should allow deep model validation', async () => {
   } catch (error) {
     expect(error.code).toBe('validationError')
   }
+})
+
+it('[regression test]: should allow correct doc cleaning for resolver params', async () => {
+  const Point = createModel({
+    name: 'Point',
+    schema: {
+      latitude: {
+        type: Number
+      },
+      longitude: {
+        type: Number
+      }
+    }
+  })
+
+  const resolver1 = resolver({
+    params: {
+      point: {
+        type: Point
+      }
+    },
+    async resolve({point}) {
+      return point
+    }
+  })
+
+  const doc = await resolver1.resolve({point: {latitude: '11', longitude: '12'}})
+
+  expect(doc).toEqual({latitude: 11, longitude: 12})
 })

--- a/packages/models/src/types/index.ts
+++ b/packages/models/src/types/index.ts
@@ -45,7 +45,7 @@ export interface CloneOptions {
   extendResolvers?: ModelResolversMap
 }
 
-export interface Model {
+export interface Model<ModelClass = any> {
   __isModel: boolean
 
   /**
@@ -71,17 +71,17 @@ export interface Model {
   /**
    * Adds the model resolvers to a item
    */
-  initItem: (item: any) => any
+  initItem: (item: ModelClass) => ModelClass
 
   /**
    * Validates an item using @orion-js/schema
    */
-  validate: (item: any) => Promise<any>
+  validate: (item: ModelClass) => Promise<any>
 
   /**
    * Cleans an item using @orion-js/schema
    */
-  clean: (item: any) => Promise<any>
+  clean: (item: ModelClass) => Promise<ModelClass>
 
   /**
    * Creates a new model using this one as a base

--- a/packages/models/yarn.lock
+++ b/packages/models/yarn.lock
@@ -265,13 +265,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/runtime@^7.5.5":
-  version "7.16.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
-  integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/template@^7.15.4", "@babel/template@^7.3.3":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
@@ -494,34 +487,35 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@orion-js/cache@^3.0.0-alpha.23":
-  version "3.0.0-alpha.23"
-  resolved "https://registry.yarnpkg.com/@orion-js/cache/-/cache-3.0.0-alpha.23.tgz#8c77577a75b50281074c21a525c7c39f0a98764d"
-  integrity sha512-/5i/5Ksnm6NOd3jGGTgVoYqvaXDITUqiXzoSAV8Fn7oIVJOWrRAvwsfVWHAfUgRZG/jCNMurID6ZGuuAk6H0XQ==
-
-"@orion-js/helpers@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@orion-js/helpers/-/helpers-3.0.0.tgz#093094e7fafc4988a3e8dad4171e0f51c0deadc6"
-  integrity sha512-6TknMsxNoeOfWJKN7/GPR6ihPMwn2VfUykiPNONqJ6La/fBDMvzr+flR4v9kIx+FudWbtip/f8HI5cRNjzGhSw==
+"@orion-js/cache@^3.0.17":
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/@orion-js/cache/-/cache-3.0.17.tgz#f5f1bda622f0dab3f0430c30583ba712b5e3d27d"
+  integrity sha512-OHXyyvFfVXzkc+p6+2wAsDFaeG9HveaedChdZByv3NmTVKP8lK6lt/bcWKfuUKdp8MK2tPfdoXs+4HIhlJxSKA==
   dependencies:
-    object-hash "^2.1.1"
+    "@orion-js/helpers" "^3.0.17"
 
-"@orion-js/resolvers@^3.0.16":
-  version "3.0.16"
-  resolved "https://registry.yarnpkg.com/@orion-js/resolvers/-/resolvers-3.0.16.tgz#5911ca5d524770a004608fff61abbccbec3044db"
-  integrity sha512-jFUPyb9ZeDeRTd+mFCnzMspZmeacol1tnzt69j/odrwn2fyR7/7qgwaS9zdJALHbYH2IZtZOu5l6aHXvUg0zKg==
+"@orion-js/helpers@^3.0.17":
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/@orion-js/helpers/-/helpers-3.0.17.tgz#fd0836cccc5ae35dba91c9b000d53004f0bc8bb4"
+  integrity sha512-XvSVfuWseXC5cnMtiuUyYgXjyX/jVh8mCw4T81P79yD6z+oH4y5ZUuweFVnmkDky1N+vfv/c5fXNGJEISR2LpQ==
   dependencies:
-    "@orion-js/cache" "^3.0.0-alpha.23"
-    "@orion-js/helpers" "^3.0.0"
-    "@orion-js/schema" "^3.0.7"
+    object-hash "^2.2.0"
 
-"@orion-js/schema@^3.0.7":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@orion-js/schema/-/schema-3.0.7.tgz#46929b880b449594432e9714fd4e40edb6da6c97"
-  integrity sha512-yZH0WGrlhwSDr/+Pw2/vNyvCLthiSE2SvHNR2WkUOD5i1dI1fwgZRcp5R3F3YyKkcmLTjDgc1foFeEfOn61cbg==
+"@orion-js/resolvers@^3.0.17":
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/@orion-js/resolvers/-/resolvers-3.0.17.tgz#a5f94beeb32656857557705b4250956c4c023554"
+  integrity sha512-1uMGiIX1Hz8YNWFr2XMr9e2IwZrXVKg5LCqvPM8Dp2GZTanE7hnyFHuZfgmhEEDJKzOyilX5LJcSEECzVfSlrw==
   dependencies:
-    "@babel/runtime" "^7.5.5"
-    dot-object "^1.9.0"
+    "@orion-js/cache" "^3.0.17"
+    "@orion-js/helpers" "^3.0.17"
+    "@orion-js/schema" "^3.0.17"
+
+"@orion-js/schema@^3.0.17":
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/@orion-js/schema/-/schema-3.0.17.tgz#0a970101c467ef42991228fb4b12731988d4d7fd"
+  integrity sha512-Q6vkZ7GsEFtQJKb2c6wU30VHDRYGY44oFb4EoLJU/KOiVP/p0zYIEolEEoEAQOmUafJDobXAgZ7SNgNWn5jAug==
+  dependencies:
+    dot-object "^2.1.4"
     lodash "^4.17.10"
 
 "@shelf/jest-mongodb@^2.1.0":
@@ -1007,10 +1001,10 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+commander@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -1123,13 +1117,13 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-dot-object@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/dot-object/-/dot-object-1.9.0.tgz#6e3d6d8379f794c5174599ddf05528f5990f076e"
-  integrity sha512-7MPN6y7XhAO4vM4eguj5+5HNKLjJYfkVG1ZR1Aput4Q4TR6SYeSjhpVQ77IzJHoSHffKbDxBC+48aCiiRurDPw==
+dot-object@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/dot-object/-/dot-object-2.1.4.tgz#c6c54e9fca510b4d0ea4d65acf33726963843b5f"
+  integrity sha512-7FXnyyCLFawNYJ+NhkqyP9Wd2yzuo+7n9pGiYpkmXCTYa8Ci2U0eUNDVg5OuO5Pm6aFXI2SWN8/N/w7SJWu1WA==
   dependencies:
-    commander "^2.20.0"
-    glob "^7.1.4"
+    commander "^4.0.0"
+    glob "^7.1.5"
 
 electron-to-chromium@^1.3.878:
   version "1.3.879"
@@ -1329,7 +1323,7 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.5:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -2219,7 +2213,7 @@ nwsapi@^2.2.0:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
-object-hash@^2.1.1:
+object-hash@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
   integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
@@ -2394,11 +2388,6 @@ readable-stream@^3.1.1, readable-stream@^3.4.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
-
-regenerator-runtime@^0.13.4:
-  version "0.13.9"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
-  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
 require-at@^1.0.6:
   version "1.0.6"

--- a/packages/mongodb/src/createCollection/getMethods/update.test.ts
+++ b/packages/mongodb/src/createCollection/getMethods/update.test.ts
@@ -2,6 +2,16 @@ import {generateId} from '@orion-js/helpers'
 import {createModel, ModelSchema} from '@orion-js/models'
 import createCollection from '..'
 
+const removeFunctions = modelItem => {
+  const newItem = {...modelItem}
+  for (const key in newItem) {
+    if (typeof newItem[key] === 'function') {
+      delete newItem[key]
+    }
+  }
+  return newItem
+}
+
 it('updates a document without errors', async () => {
   const Tests = createCollection({name: generateId()})
 
@@ -42,7 +52,7 @@ it('should update documents that have array passing validation', async () => {
 
   await Tests.updateOne(personId, {$set: {'friends.0.name': 'Robert'}})
 
-  expect(await Tests.findOne(personId)).toEqual({
+  expect(removeFunctions(await Tests.findOne(personId))).toEqual({
     _id: personId,
     friends: [{name: 'Robert'}, {name: 'Joaquín'}]
   })
@@ -52,7 +62,7 @@ it('should update documents that have array passing validation', async () => {
       friends: {name: 'Bastian'}
     }
   })
-  expect(await Tests.findOne(personId)).toEqual({
+  expect(removeFunctions(await Tests.findOne(personId))).toEqual({
     _id: personId,
     friends: [{name: 'Robert'}, {name: 'Joaquín'}, {name: 'Bastian'}]
   })
@@ -73,7 +83,7 @@ it('should do $pull operation', async () => {
   await Tests.updateOne(itemId, {$pull: {tags: '1'}})
   await Tests.updateOne(itemId, {$pull: {tags: {$in: ['3', '4']}}})
 
-  expect(await Tests.findOne(itemId)).toEqual({
+  expect(removeFunctions(await Tests.findOne(itemId))).toEqual({
     _id: itemId,
     tags: ['2']
   })
@@ -98,7 +108,7 @@ it('should update documents passing validation', async () => {
   await Tests.updateOne(personId, {$set: {'wife.state': 'Full'}})
 
   const doc = await Tests.findOne(personId)
-  expect(doc).toEqual({_id: personId, wife: {state: 'Full', name: 'Francisca'}})
+  expect(removeFunctions(doc)).toEqual({_id: personId, wife: {state: 'Full', name: 'Francisca'}})
 })
 
 it('should handle $inc operator on blackbox', async () => {
@@ -122,7 +132,7 @@ it('should handle $inc operator on blackbox', async () => {
 
   const doc = await Tests.findOne(userId)
 
-  expect(doc).toEqual({_id: userId, services: {phoneVerification: {tries: 2}}})
+  expect(removeFunctions(doc)).toEqual({_id: userId, services: {phoneVerification: {tries: 2}}})
 })
 
 it('should update documents passing validation with blackbox field', async () => {
@@ -142,7 +152,10 @@ it('should update documents passing validation with blackbox field', async () =>
   await Tests.updateOne(personId, {$set: {'services.forgot': 'mypassword'}})
 
   const doc = await Tests.findOne(personId)
-  expect(doc).toEqual({_id: personId, services: {password: 123456, forgot: 'mypassword'}})
+  expect(removeFunctions(doc)).toEqual({
+    _id: personId,
+    services: {password: 123456, forgot: 'mypassword'}
+  })
 })
 
 it('should throw an error when modifier is invalid', async () => {
@@ -195,7 +208,7 @@ it('dont add autovalue when updating', async () => {
   const personId = await Tests.insertOne({name: 'Nicolás'})
   await Tests.updateOne(personId, {$set: {name: 'Nicolás López'}})
   const doc = await Tests.findOne(personId)
-  expect(doc).toEqual({_id: personId, name: 'Nicolás López', count: 1})
+  expect(removeFunctions(doc)).toEqual({_id: personId, name: 'Nicolás López', count: 1})
 })
 
 it('should handle $ correctly', async () => {
@@ -228,7 +241,7 @@ it('should handle $ correctly', async () => {
     }
   )
 
-  expect(await Tests.findOne(userId)).toEqual({
+  expect(removeFunctions(await Tests.findOne(userId))).toEqual({
     _id: userId,
     emails: [
       {

--- a/packages/mongodb/src/createCollection/getMethods/upsert.test.ts
+++ b/packages/mongodb/src/createCollection/getMethods/upsert.test.ts
@@ -2,6 +2,16 @@ import {generateId} from '@orion-js/helpers'
 import {createModel, ModelSchema} from '@orion-js/models'
 import createCollection from '..'
 
+const removeFunctions = modelItem => {
+  const newItem = {...modelItem}
+  for (const key in newItem) {
+    if (typeof newItem[key] === 'function') {
+      delete newItem[key]
+    }
+  }
+  return newItem
+}
+
 it('updates a document if exists', async () => {
   const Tests = createCollection({name: generateId()})
 
@@ -62,7 +72,7 @@ it('adds default value when creating docs', async () => {
   expect(calls).toBe(1)
   expect(typeof upsertedId).toBe('string')
   const final = await Tests.findOne({})
-  expect(final).toEqual({
+  expect(removeFunctions(final)).toEqual({
     _id: upsertedId,
     firstName: 'Nicolás',
     lastName: 'Ermann',
@@ -101,7 +111,7 @@ it('should upsert documents passing cleaning validation', async () => {
   await Tests.updateOne(upsertedId, {$set: {'wife.state': 'Full'}})
 
   const doc = await Tests.findOne(upsertedId)
-  expect(doc).toEqual({
+  expect(removeFunctions(doc)).toEqual({
     _id: upsertedId,
     name: 'Nicolás',
     label: '1234',

--- a/packages/mongodb/src/createCollection/initItem.ts
+++ b/packages/mongodb/src/createCollection/initItem.ts
@@ -1,11 +1,43 @@
-import {Collection, InitItem} from '../types'
+import {
+  Collection,
+  InitItem,
+  ModelItem,
+  ModelToUpdateFilter,
+  DocumentWithId,
+  UpdateOptions,
+  ModelItemEnhancements
+} from '../types'
+import updateOne from './getMethods/updateOne'
 
-export default (collection: Partial<Collection>) => {
-  const initItem = doc => {
+const isDocumentWithId = <ModelClass = any>(doc: ModelClass): doc is DocumentWithId<ModelClass> => {
+  return doc && '_id' in doc
+}
+
+export default function initItem<ModelClass = any>(
+  collection: Partial<Collection<ModelClass>>
+): (doc: ModelClass) => ModelItem<ModelClass> {
+  const initItem = (doc: ModelClass): ModelItem<ModelClass> => {
     if (!doc) return doc
     if (!collection.model) return doc
 
-    return collection.model.initItem(doc)
+    if (!isDocumentWithId(doc)) return doc
+
+    const result: Partial<ModelItem<ModelClass>> = collection.model.initItem(doc)
+
+    ;(result as ModelItemEnhancements<ModelClass>).update = async (
+      modifier: ModelToUpdateFilter<ModelClass>,
+      options?: UpdateOptions
+    ) => {
+      const updateResult = await collection.updateOne(doc._id, modifier, options)
+      const updatedDoc = await collection.findOne(doc._id)
+      for (const key in updatedDoc) {
+        ;(doc as ModelClass)[key] = updatedDoc[key]
+      }
+
+      return updateResult
+    }
+
+    return result as ModelItem<ModelClass>
   }
 
   return initItem

--- a/packages/mongodb/src/createCollection/typedModel.test.ts
+++ b/packages/mongodb/src/createCollection/typedModel.test.ts
@@ -59,4 +59,27 @@ describe('Collections with typed model', () => {
 
     expect(title).toBe('Mr. John Doe')
   })
+
+  it('Should pass the update method to the items', async () => {
+    const Persons = createCollection<Person>({
+      name: generateId(),
+      model: getModelForClass(Person)
+    })
+
+    await Persons.insertOne({
+      firstName: 'John',
+      lastName: 'Doe'
+    })
+
+    const person = await Persons.findOne({})
+    await person.update({$set: {firstName: 'Alice'}})
+
+    expect(person.firstName).toBe('Alice')
+
+    const updatedPerson = await Persons.findOne({})
+    expect(updatedPerson.firstName).toBe('Alice')
+    const title = await person.title({title: 'Ms.'})
+
+    expect(title).toBe('Ms. Alice Doe')
+  })
 })

--- a/packages/mongodb/src/types/index.ts
+++ b/packages/mongodb/src/types/index.ts
@@ -89,23 +89,36 @@ export interface InsertOptions {
   mongoOptions?: MongoDB.InsertOneOptions
 }
 
-export type InitItem<ModelClass> = (doc: MongoDB.Document) => ModelClass
+export interface ModelItemEnhancements<ModelClass = any> {
+  /**
+   * Updates the document in MongoDB. Also modifies the model item in memory to reflect the updates.
+   * Only available for model items that have an ID.
+   */
+  update?: (
+    modifier: ModelToUpdateFilter<ModelClass>,
+    options?: UpdateOptions
+  ) => Promise<MongoDB.UpdateResult>
+}
+
+export type ModelItem<ModelClass = any> = ModelClass & ModelItemEnhancements<ModelClass>
+
+export type InitItem<ModelClass> = (doc: MongoDB.Document) => ModelItem<ModelClass>
 
 export type FindOne<ModelClass> = (
   selector?: ModelToMongoSelector<ModelClass>,
   options?: MongoDB.FindOptions
-) => Promise<ModelClass>
+) => Promise<ModelItem<ModelClass>>
 
 export type Find<ModelClass> = (
   selector?: ModelToMongoSelector<ModelClass>,
   options?: MongoDB.FindOptions
-) => FindCursor<ModelClass>
+) => FindCursor<ModelItem<ModelClass>>
 
 export type FindOneAndUpdate<ModelClass> = (
   selector: ModelToMongoSelector<ModelClass>,
   modifier: ModelToUpdateFilter<ModelClass>,
   options?: FindOneAndUpdateUpdateOptions
-) => Promise<ModelClass>
+) => Promise<ModelItem<ModelClass>>
 
 export type InsertOne<ModelClass> = (
   doc: ModelToDocumentTypeWithoutId<ModelClass>,
@@ -160,7 +173,7 @@ export type CreateCollection = <ModelClass = any>(
 export interface Collection<ModelClass = any> {
   name: string
   connectionName?: string
-  model?: Model
+  model?: Model<ModelClass>
   indexes: Array<CollectionIndex>
   generateId: () => string
   getSchema: () => Schema

--- a/packages/mongodb/yarn.lock
+++ b/packages/mongodb/yarn.lock
@@ -487,6 +487,58 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@orion-js/cache@^3.0.17":
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/@orion-js/cache/-/cache-3.0.17.tgz#f5f1bda622f0dab3f0430c30583ba712b5e3d27d"
+  integrity sha512-OHXyyvFfVXzkc+p6+2wAsDFaeG9HveaedChdZByv3NmTVKP8lK6lt/bcWKfuUKdp8MK2tPfdoXs+4HIhlJxSKA==
+  dependencies:
+    "@orion-js/helpers" "^3.0.17"
+
+"@orion-js/helpers@^3.0.17":
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/@orion-js/helpers/-/helpers-3.0.17.tgz#fd0836cccc5ae35dba91c9b000d53004f0bc8bb4"
+  integrity sha512-XvSVfuWseXC5cnMtiuUyYgXjyX/jVh8mCw4T81P79yD6z+oH4y5ZUuweFVnmkDky1N+vfv/c5fXNGJEISR2LpQ==
+  dependencies:
+    object-hash "^2.2.0"
+
+"@orion-js/models@^3.0.20":
+  version "3.0.20"
+  resolved "https://registry.yarnpkg.com/@orion-js/models/-/models-3.0.20.tgz#ecf3409ff5a486a1631adc3445799bd1544ae6f8"
+  integrity sha512-c3AnRWq+qYixEgtnT0nujFlVjwuX6BYf9ebfbwAHZe7f80w1ky5ulKyHWZh9V3P3uWESeKhybZj6IQMcKoCHTQ==
+  dependencies:
+    "@orion-js/helpers" "^3.0.17"
+    "@orion-js/resolvers" "^3.0.17"
+    "@orion-js/schema" "^3.0.17"
+
+"@orion-js/resolvers@^3.0.17":
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/@orion-js/resolvers/-/resolvers-3.0.17.tgz#a5f94beeb32656857557705b4250956c4c023554"
+  integrity sha512-1uMGiIX1Hz8YNWFr2XMr9e2IwZrXVKg5LCqvPM8Dp2GZTanE7hnyFHuZfgmhEEDJKzOyilX5LJcSEECzVfSlrw==
+  dependencies:
+    "@orion-js/cache" "^3.0.17"
+    "@orion-js/helpers" "^3.0.17"
+    "@orion-js/schema" "^3.0.17"
+
+"@orion-js/schema@^3.0.17":
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/@orion-js/schema/-/schema-3.0.17.tgz#0a970101c467ef42991228fb4b12731988d4d7fd"
+  integrity sha512-Q6vkZ7GsEFtQJKb2c6wU30VHDRYGY44oFb4EoLJU/KOiVP/p0zYIEolEEoEAQOmUafJDobXAgZ7SNgNWn5jAug==
+  dependencies:
+    dot-object "^2.1.4"
+    lodash "^4.17.10"
+
+"@orion-js/typed-model@^3.0.20":
+  version "3.0.20"
+  resolved "https://registry.yarnpkg.com/@orion-js/typed-model/-/typed-model-3.0.20.tgz#a89647b3541b95af3d9381091cb522a2255fcfee"
+  integrity sha512-8Us7nom7SpGYBUcA9x1yGZqVQqoqgMul0Yy1pSloSMi0BlX78RwTBkB59Bxjilt+NoAw2Fi/sor3K7+KuFMzFQ==
+  dependencies:
+    "@orion-js/helpers" "^3.0.17"
+    "@orion-js/models" "^3.0.20"
+    "@orion-js/resolvers" "^3.0.17"
+    "@orion-js/schema" "^3.0.17"
+    lodash "^4.17.21"
+    reflect-metadata "0.1.13"
+
 "@shelf/jest-mongodb@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@shelf/jest-mongodb/-/jest-mongodb-2.1.0.tgz#2179b53b8e01dde1315b9f333cc2945dd89a6940"
@@ -1121,7 +1173,7 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-dot-object@2.1.4:
+dot-object@2.1.4, dot-object@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/dot-object/-/dot-object-2.1.4.tgz#c6c54e9fca510b4d0ea4d65acf33726963843b5f"
   integrity sha512-7FXnyyCLFawNYJ+NhkqyP9Wd2yzuo+7n9pGiYpkmXCTYa8Ci2U0eUNDVg5OuO5Pm6aFXI2SWN8/N/w7SJWu1WA==
@@ -2035,7 +2087,7 @@ lodash.memoize@4.x:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash@^4.7.0:
+lodash@^4.17.10, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2236,6 +2288,11 @@ nwsapi@^2.2.0:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
+object-hash@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+
 once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -2406,6 +2463,11 @@ readable-stream@^3.1.1, readable-stream@^3.4.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+reflect-metadata@0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
 require-at@^1.0.6:
   version "1.0.6"

--- a/packages/resolvers/src/resolver/getExecute/getSchema.ts
+++ b/packages/resolvers/src/resolver/getExecute/getSchema.ts
@@ -10,9 +10,9 @@ export default function (resolverParams: any) {
     const isArrayOfModel = isArray(field.type) && field.type[0].__isModel
 
     if (isArrayOfModel) {
-      field.type = [field.type[0].schema]
+      field.type = [field.type[0].getSchema()]
     } else if (field.type.__isModel) {
-      field.type = field.type.schema
+      field.type = field.type.getSchema()
     }
 
     schema[key] = field


### PR DESCRIPTION
# Changelog

Allows doing the following:

```javascript
const item = Model.findOne(...)
await item.update({$set: {...}})
```

Which updates the value both in mongodb and in memory.

Also fixes a bug in resolvers.