### PR TITLE
Implement dotenv

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "colors": "^1.4.0",
     "commander": "^8.3.0",
     "comment-json": "^4.1.1",
+    "dotenv": "^16.0.0",
     "lodash": "^4.17.21",
     "typescript": "^4.4.4"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ import colors from 'colors/safe'
 import test from './test'
 import './handleErrors'
 import version from './version'
+import 'dotenv/config'
 
 const program = new Command()
 

--- a/packages/core/yarn.lock
+++ b/packages/core/yarn.lock
@@ -146,6 +146,11 @@ denque@^1.4.1:
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.1.tgz#07f670e29c9a78f8faecb2566a1e2c11929c5cbf"
   integrity sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==
 
+dotenv@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.0.tgz#c619001253be89ebb638d027b609c75c26e47411"
+  integrity sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==
+
 end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"


### PR DESCRIPTION
Permite la utilización de archivos `.env`, para agregar variables de entorno.

Esto permite a los nuevos desarrolladores estar más familiarizados con la carga de variables de entorno a través de archivos `.env` en vez de `.sh`, que es lo que se acostumbra usar hoy en día en frameworks para Node.