### PR TITLE
Adds red test to switch validation order

### DIFF
--- a/packages/schema/src/validateRoot.test.ts
+++ b/packages/schema/src/validateRoot.test.ts
@@ -1,0 +1,25 @@
+import { Schema } from '.'
+import validate from './validate'
+
+describe('Tests for global docuement validation',  () => {
+  it('Should validate the root document after the leaves', async () => {
+    const calls = []
+    const schema: Schema = {
+      name: {
+        type: 'string',
+        validate: () => {
+          calls.push('leaf')
+        }
+      },
+      __validate: () => {
+        calls.push('root')
+      }
+    }
+
+    await validate(schema, {name: 'Gabo'})
+
+
+    expect(calls).toEqual(['leaf', 'root'])
+
+  })
+})


### PR DESCRIPTION
# Changelog
- Se invierte el orden de validación en un objeto `schema`, de modo que las hojas del objeto son validadas antes que el tronco