### PR TITLE
Chore(echoes): add async version of startService and additional option

### DIFF
--- a/packages/echoes/src/startService/index.ts
+++ b/packages/echoes/src/startService/index.ts
@@ -5,7 +5,7 @@ import types from '../echo/types'
 import {EchoesOptions} from '../types'
 import {registerRoute} from '@orion-js/http'
 
-export default function (options: EchoesOptions) {
+export default async function startService(options: EchoesOptions) {
   config.echoes = options.echoes
 
   if (options.requests) {
@@ -19,14 +19,17 @@ export default function (options: EchoesOptions) {
     config.producer = kafka.producer(options.producer)
     config.consumer = kafka.consumer(options.consumer)
 
-    config.producer.connect()
-    config.consumer.connect()
+    await config.producer.connect()
+    await config.consumer.connect()
 
     for (const topic in options.echoes) {
       const echo = options.echoes[topic]
       if (echo.type !== types.event) continue
 
-      config.consumer.subscribe({topic})
+      await config.consumer.subscribe({
+        topic,
+        fromBeginning: options.readTopicsFromBeginning ?? false
+      })
     }
 
     config.consumer.run({

--- a/packages/echoes/src/types.ts
+++ b/packages/echoes/src/types.ts
@@ -86,6 +86,11 @@ export interface EchoesOptions {
   consumer?: ConsumerConfig
   requests?: RequestsConfig
   echoes: EchoesMap
+
+  /**
+   * Defaults to false. When true, allows a reconnecting service to read missed messages.
+   */
+  readTopicsFromBeginning?: boolean
 }
 
 export interface EchoesConfigHandler {


### PR DESCRIPTION
# Changelog

- Adds the `readTopicsFromBeginning` option to echoes topics.
- Adds await to the async operations when starting Kafka.