### PR TITLE
Fix: remove selector from estimated count

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.6.3",
+  "version": "2.6.4",
   "npmClient": "yarn"
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/app",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "main": "lib/index.js",
   "author": "nicolaslopezj",
   "license": "MIT",
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.14.0",
-    "@orion-js/schema": "^2.6.3",
+    "@orion-js/schema": "^2.6.4",
     "colors": "^1.3.3",
     "dataloader": "^2.0.0",
     "dot-object": "^1.9.0",

--- a/packages/app/src/collection/getMethods/find.js
+++ b/packages/app/src/collection/getMethods/find.js
@@ -36,7 +36,15 @@ export default ({rawCollection, initItem}) =>
         return await rawCollection.countDocuments(selector)
       },
       async estimatedCount() {
-        return await rawCollection.estimatedDocumentCount(selector)
+        return await rawCollection.estimatedDocumentCount()
+      },
+      async fastCount() {
+        // Return estimated count if no selector
+        if (Object.keys(selector).length === 0) {
+          return await rawCollection.estimatedDocumentCount()
+        }
+
+        return await await rawCollection.countDocuments(selector)
       },
       async toArray() {
         const items = await cursor.rawCursor.toArray()

--- a/packages/app/src/resolvers/paginatedResolver/getModel.js
+++ b/packages/app/src/resolvers/paginatedResolver/getModel.js
@@ -5,7 +5,7 @@ import resolver from '../resolver'
 export default ({returns, modelName}) => {
   const getTotalCount = async function (paginated) {
     if (typeof paginated.count === 'undefined') {
-      paginated.count = paginated.cursor.estimatedCount()
+      paginated.count = paginated.cursor?.fastCount?.() ?? paginated.cursor?.count?.() ?? 1
     }
     return await paginated.count
   }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/auth",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "main": "lib/index.js",
   "author": "nicolaslopezj",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/runtime": "^7.5.5",
-    "@orion-js/app": "^2.6.3",
+    "@orion-js/app": "^2.6.4",
     "babel-jest": "^23.4.2",
     "jest": "^23.5.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/cli",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "main": "index.js",
   "author": "nicolaslopezj",
   "license": "MIT",

--- a/packages/echoes/package.json
+++ b/packages/echoes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/echoes",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "main": "lib/index.js",
   "author": "nicolaslopezj",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "test:watch": "jest src --coverage --watch"
   },
   "dependencies": {
-    "@orion-js/helpers": "^2.6.3",
+    "@orion-js/helpers": "^2.6.4",
     "axios": "^0.23.0",
     "jssha": "^3.2.0",
     "kafkajs": "^1.15.0",

--- a/packages/file-manager/package.json
+++ b/packages/file-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/file-manager",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "main": "lib/index.js",
   "author": "nicolaslopezj",
   "license": "MIT",
@@ -21,7 +21,7 @@
     "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/runtime": "^7.5.5",
-    "@orion-js/app": "^2.6.3",
+    "@orion-js/app": "^2.6.4",
     "babel-jest": "^22.4.3",
     "jest": "^22.4.3"
   },

--- a/packages/graphql-client/package.json
+++ b/packages/graphql-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/graphql-client",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "main": "lib/index.js",
   "author": "nicolaslopezj",
   "license": "MIT",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/graphql",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "main": "lib/index.js",
   "author": "nicolaslopezj",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@orion-js/schema": "^2.6.3",
+    "@orion-js/schema": "^2.6.4",
     "apollo-server-core": "3.4.0",
     "apollo-server-micro": "3.4.0",
     "deep-sort-object": "^1.0.2",
@@ -26,7 +26,7 @@
     "@babel/plugin-transform-runtime": "^7.11.0",
     "@babel/preset-env": "^7.11.0",
     "@babel/runtime": "^7.11.2",
-    "@orion-js/app": "^2.6.3",
+    "@orion-js/app": "^2.6.4",
     "babel-jest": "^26.2.2",
     "graphql": "^15.6.0",
     "jest": "^26.2.2"

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/helpers",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "main": "lib/index.js",
   "author": "nicolaslopezj",
   "license": "MIT",

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/jobs",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "main": "lib/index.js",
   "author": "nicolaslopezj",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "@babel/core": "^7.5.5",
     "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
-    "@orion-js/app": "^2.6.3",
+    "@orion-js/app": "^2.6.4",
     "babel-jest": "^26.6.3",
     "jest": "^26.6.3",
     "mongodb-memory-server": "^8.15.1"

--- a/packages/mailing/package.json
+++ b/packages/mailing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/mailing",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "main": "lib/index.js",
   "author": "nicolaslopezj",
   "license": "MIT",
@@ -21,7 +21,7 @@
     "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/runtime": "^7.5.5",
-    "@orion-js/app": "^2.6.3",
+    "@orion-js/app": "^2.6.4",
     "babel-jest": "^22.4.3",
     "jest": "^22.4.3"
   },

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/schema",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "main": "lib/index.js",
   "author": "nicolaslopezj",
   "license": "MIT",


### PR DESCRIPTION
# Changelog

- Removes selector from `estimatedDocumentCount` query as it's not available.
- Fallback for paginated resolver count.
