### PR TITLE
Danielmerrill/2.8.4

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/graphql",
-  "version": "2.8.3-alpha-1",
+  "version": "2.8.3",
   "main": "lib/index.js",
   "author": "nicolaslopezj",
   "license": "MIT",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/graphql",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "main": "lib/index.js",
   "author": "nicolaslopezj",
   "license": "MIT",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-js/graphql",
-  "version": "2.8.2",
+  "version": "2.8.3-alpha-1",
   "main": "lib/index.js",
   "author": "nicolaslopezj",
   "license": "MIT",

--- a/packages/graphql/src/getOperationName.js
+++ b/packages/graphql/src/getOperationName.js
@@ -1,14 +1,17 @@
 export default async function getOperationName(params) {
   const {request, getBodyJSON} = params
+  try {
+    if (request.method !== 'GET') {
+      const data = await getBodyJSON()
+      return data.operationName
+    }
 
-  if (request.method !== 'GET') {
-    const data = await getBodyJSON()
-    return data.operationName
-  }
-
-  if (request.method === 'GET') {
-    // handle persisted queries
-    const queryParams = new URLSearchParams(request.url.split('?')[1])
-    return queryParams.get('operationName')
+    if (request.method === 'GET') {
+      // handle persisted queries
+      const queryParams = new URLSearchParams(request.url.split('?')[1])
+      return queryParams.get('operationName')
+    }
+  } catch (error) {
+    return null
   }
 }

--- a/packages/graphql/src/startGraphQL.js
+++ b/packages/graphql/src/startGraphQL.js
@@ -7,6 +7,7 @@ import micro from 'micro'
 import {runHttpQuery} from 'apollo-server-core'
 import {InMemoryLRUCache} from 'apollo-server-caching'
 import getOperationName from './getOperationName'
+import storePersistedQuery from './storePersistedQuery'
 
 global.globalMicro = micro
 
@@ -47,6 +48,8 @@ export default async function (options) {
 
         const result = await options.executeGraphQLCache(params, fallback)
         if (result) {
+          await storePersistedQuery(apolloOptions, params)
+
           if (result.cacheControl && cacheKey) {
             cacheControlCache.set(cacheKey, result.cacheControl)
             response.setHeader('Cache-Control', result.cacheControl)

--- a/packages/graphql/src/storePersistedQuery.js
+++ b/packages/graphql/src/storePersistedQuery.js
@@ -1,0 +1,33 @@
+export const APQ_CACHE_PREFIX = 'apq:'
+
+function createSHA(algorithm) {
+  return require('crypto').createHash(algorithm)
+}
+
+function computeQueryHash(query) {
+  return createSHA('sha256').update(query).digest('hex')
+}
+
+export default async function storePersistedQuery(apolloConfig, params) {
+  const queryCache = apolloConfig.persistedQueries.cache
+  if (!queryCache) {
+    return
+  }
+
+  if (params.request.method !== 'POST') {
+    return
+  }
+
+  const data = await params.getBodyJSON()
+
+  if (!data?.query) {
+    return
+  }
+
+  const hash = APQ_CACHE_PREFIX + computeQueryHash(data.query)
+
+  const ttl =
+    apolloConfig.persistedQueries?.ttl !== undefined ? apolloConfig.persistedQueries.ttl : 60 * 15
+
+  await queryCache.set(hash, data.query, {ttl})
+}


### PR DESCRIPTION
# Changelog

Previously, when returning request responses from the cache handler, they would not be stored to Apollo Persisted Queries cache if they were APQ requests. This is fixed in this version.