### PR TITLE
 Conditional Joining, Dead Letter, and Retry Mechanisms to Echoes

### DIFF
--- a/packages/echoes/src/index.js
+++ b/packages/echoes/src/index.js
@@ -1,6 +1,6 @@
-import startService from './startService'
+import startService, { stopService } from './startService'
 import publish from './publish'
 import echo from './echo'
 import request from './request'
 
-export {publish, startService, echo, request}
+export { publish, startService, stopService, echo, request }

--- a/packages/echoes/src/publish/index.js
+++ b/packages/echoes/src/publish/index.js
@@ -7,15 +7,15 @@ import serialize from './serialize'
  * @param  {Object} params
  */
 export default async function (options) {
-  if (!config.producer) {
-    throw new Error('You must initialize echoes configruation to use publish')
+  if (!config.kafkaManager) {
+    throw new Error('You must initialize echoes configuration to use publish')
   }
 
   const payload = {
     params: options.params
   }
 
-  return await config.producer.send({
+  return await config.kafkaManager.producer.send({
     acks: options.acks,
     timeout: options.timeout,
     topic: options.topic,

--- a/packages/echoes/src/startService/KafkaManager.js
+++ b/packages/echoes/src/startService/KafkaManager.js
@@ -1,0 +1,136 @@
+import { Kafka } from 'kafkajs'
+import types from '../echo/types'
+
+const HEARTBEAT_INTERVAL_SECONDS = 5
+const CHECK_JOIN_CONSUMER_INTERVAL_SECONDS = 30
+
+class KafkaManager {
+  constructor(options) {
+    this.kafka = new Kafka(options.client)
+    this.options = options
+    this.producer = this.kafka.producer(options.producer)
+    this.consumer = this.kafka.consumer({ groupId: options.consumer.groupId })
+    this.topics = Object.keys(options.echoes).filter(key => options.echoes[key].type === types.event)
+  }
+
+  async checkJoinConsumerGroupConditions() {
+    const admin = this.kafka.admin()
+    await admin.connect()
+    const groupDescriptions = await admin.describeGroups([this.options.consumer.groupId])
+    const group = groupDescriptions.groups[0]
+    if (group.state === 'Empty') {
+      console.info(`Echoes: Consumer group ${this.options.consumer.groupId} is empty`)
+      return true
+    }
+    const topicsMetadata = await admin.fetchTopicMetadata({ topics: this.topics })
+    const totalPartitions = topicsMetadata.topics.reduce((acc, t) => acc + t.partitions.length, 0)
+    console.info(`Echoes: Consumer group ${this.options.consumer.groupId} has ${group.members.length} members and ${totalPartitions} partitions`)
+    if (totalPartitions > group.members.length) {
+      return true
+    }
+    await admin.disconnect()
+  }
+
+  async joinConsumerGroup() {
+    await this.consumer.connect()
+    await this.consumer.subscribe({ topics: this.topics })
+    this.consumer.run({
+      partitionsConsumedConcurrently: this.options.partitionsConsumedConcurrently || 4,
+      eachMessage: (params) => this.handleMessage(params),
+    })
+  }
+
+  async conditionalStart() {
+    if (await this.checkJoinConsumerGroupConditions()) {
+      await this.joinConsumerGroup()
+      return true
+    }
+  }
+
+  async start() {
+    if (this.started) return
+    await this.producer.connect()
+    console.info("PRODUCER CONNECTED")
+    this.started = await this.conditionalStart()
+    if (this.started) return
+    console.info('Echoes: Delaying consumer group join, waiting for conditions to be met')
+    this.interval = setInterval(async () => {
+      this.started = await this.conditionalStart()
+      if (this.started) clearInterval(this.interval)
+    }, CHECK_JOIN_CONSUMER_INTERVAL_SECONDS * 1000)
+  }
+
+  async stop() {
+    console.warn("Echoes: Stopping echoes")
+    if (this.interval) {
+      clearInterval(this.interval)
+    }
+    if (this.consumer) {
+      await this.consumer.disconnect()
+    }
+    if (this.producer) {
+      await this.producer.disconnect()
+    }
+  }
+
+  async handleMessage(params) {
+    const echo = this.options.echoes[params.topic]
+    if (!echo || echo.type !== types.event) {
+      console.warn(`Echoes: Received a message for an unknown topic: ${params.topic}, ignoring it`)
+    }
+
+    let intervalsCount = 0
+    const hInterval = setInterval(async () => {
+      await params.heartbeat().catch(error => {
+        console.warn('Echoes: Error sending heartbeat:', error)
+      })
+      intervalsCount++
+      if (intervalsCount % 10 === 0) {
+        console.warn(`Echoes: Event ${params.topic} is taking too long to process: ${intervalsCount * HEARTBEAT_INTERVAL_SECONDS}s`)
+      }
+    }, HEARTBEAT_INTERVAL_SECONDS * 1000)
+
+    try {
+      await echo.onMessage(params)
+        .catch(error => this.handleRetries(echo, params, error))
+    } catch (error) {
+      console.error('Echoes: error processing message:', { error, params })
+      throw error
+    } finally {
+      clearInterval(hInterval)
+    }
+  }
+
+  async handleRetries(echo, params, error) {
+    const { message, topic } = params
+    const retries = getRetries(message)
+    if (echo.attemptsBeforeDeadLetter === undefined || echo.attemptsBeforeDeadLetter === null) {
+      throw error
+    }
+    const maxRetries = echo.attemptsBeforeDeadLetter || 0
+    const execededMaxRetries = retries >= maxRetries
+    const nextTopic = execededMaxRetries ? `DLQ-${topic}` : topic
+    await this.producer.send({
+      topic: nextTopic,
+      messages: [{
+        value: message.value.toString(),
+        headers: {
+          retries: String(retries + 1),
+          errorMessage: error.message
+        }
+      }]
+    })
+    if (execededMaxRetries) {
+      console.error(`Echoes: a message has reached the maximum number of retries, sending it to DLQ: ${nextTopic}`)
+    } else {
+      console.warn(`Echoes: a retryable message failed "${error.message}", re-sending it to topic: ${nextTopic}`)
+    }
+  }
+}
+
+function getRetries(message) {
+  if (!message || !message.headers || !message.headers.retries) return 0
+  return Number.parseInt(message.headers.retries.toString())
+}
+
+export default KafkaManager

--- a/packages/echoes/src/startService/index.js
+++ b/packages/echoes/src/startService/index.js
@@ -1,90 +1,13 @@
-import { AssignerProtocol, Kafka } from 'kafkajs'
 import config from '../config'
 import requestsHandler from '../requestsHandler'
-import types from '../echo/types'
+import KafkaManager from './KafkaManager'
 
-const HEARTBEAT_INTERVAL_SECONDS = 3
-
+let kafkaManager = null
 export default async function startService(options) {
   if (options.client) {
-    const kafka = new Kafka(options.client)
-    const admin = kafka.admin()
-    await admin.connect()
-
-    const checkConsumerGroup = async (consumerGroupId) => {
-      console.info(`Checking consumer group ${consumerGroupId}`)
-      const groupDescriptions = await admin.describeGroups([consumerGroupId])
-      const group = groupDescriptions.groups[0]
-      if (group.state === 'Empty') return true
-      const topics = Object.keys(options.echoes).filter(key => options.echoes[key].type === types.event)
-      const topicsMetadata = await admin.fetchTopicMetadata({ topics })
-      const maxPartitions = Math.max(...topicsMetadata.topics.map(t => t.partitions.length))
-      if (maxPartitions > group.members.length) {
-        console.warn(`There are more partitions (${maxPartitions}) than members (${group.members.length}) in the group ${consumerGroupId}`)
-        return true
-      }
-    }
-
-    config.producer = kafka.producer(options.producer)
-    const consumers = {}
-    for (const [topic, echo] of Object.entries(options.echoes)) {
-      if (echo.type !== types.event) continue
-      const consumerId = echo.consumerId ? `${options.consumer.groupId}-${echo.consumerId}` : options.consumer.groupId
-      if (!consumers[consumerId]) consumers[consumerId] = []
-      consumers[consumerId].push(topic)
-    }
-
-    console.info('Consumers:', Object.keys(consumers))
-
-    const joinConsumerGroup = async (consumer, topics) => {
-      await consumer.connect()
-      await consumer.subscribe({ topics })
-      config.consumer.run({
-        eachMessage: async params => {
-          const echo = options.echoes[params.topic]
-          if (!echo) return
-          if (echo.type !== types.event) return
-          let intervalsCount = 0
-          const interval = setInterval(async () => {
-            await params.heartbeat().catch(error => {
-              console.warn('Echoes: Error sending heartbeat:', error)
-            })
-            intervalsCount++
-            if (intervalsCount % 10 === 0) {
-              console.warn(`Echoes: Event ${params.topic} is taking too long to process: ${intervalsCount * HEARTBEAT_INTERVAL_SECONDS}s`)
-            }
-          }, HEARTBEAT_INTERVAL_SECONDS * 1000)
-          await echo.onMessage(params).catch(error => {
-            clearInterval(interval)
-            throw error
-          })
-          clearInterval(interval)
-        },
-      })
-    }
-
-
-    await config.producer.connect()
-
-    for (const [consumerId, topics] of Object.entries(consumers)) {
-      console.info(`Creating consumer ${consumerId} for topics ${topics}`)
-      const consumer = kafka.consumer({ groupId: consumerId })
-      if (await checkConsumerGroup(consumerId)) {
-        console.info(`Joining consumer group inmediately ${consumerId}`)
-        await joinConsumerGroup(consumer, topics)
-      } else {
-        console.info(`The consumer group has enough members, waiting to join ${consumerId}`)
-        const interval = setInterval(async () => {
-          if (await checkConsumerGroup(consumerId)) {
-            console.info(`Joining consumer group after checking ${consumerId}`)
-            await joinConsumerGroup(consumer, topics)
-            clearInterval(interval)
-          }
-        }, 5000)
-      }
-    }
-
-
+    kafkaManager = new KafkaManager(options)
+    await kafkaManager.start()
+    config.kafkaManager = kafkaManager
   }
   if (options.requests) {
     config.requests = options.requests
@@ -93,5 +16,13 @@ export default async function startService(options) {
     if (config.requests.startHandler) {
       config.requests.startHandler(requestsHandler)
     }
+  }
+}
+
+export async function stopService() {
+  if (kafkaManager) {
+    console.info("Stoping echoes...")
+    await kafkaManager.stop()
+    console.info("Echoes stopped")
   }
 }

--- a/packages/echoes/src/startService/index.js
+++ b/packages/echoes/src/startService/index.js
@@ -1,4 +1,4 @@
-import { Kafka } from 'kafkajs'
+import { AssignerProtocol, Kafka } from 'kafkajs'
 import config from '../config'
 import requestsHandler from '../requestsHandler'
 import types from '../echo/types'
@@ -8,45 +8,83 @@ const HEARTBEAT_INTERVAL_SECONDS = 3
 export default async function startService(options) {
   if (options.client) {
     const kafka = new Kafka(options.client)
+    const admin = kafka.admin()
+    await admin.connect()
+
+    const checkConsumerGroup = async (consumerGroupId) => {
+      console.info(`Checking consumer group ${consumerGroupId}`)
+      const groupDescriptions = await admin.describeGroups([consumerGroupId])
+      const group = groupDescriptions.groups[0]
+      if (group.state === 'Empty') return true
+      const topics = Object.keys(options.echoes).filter(key => options.echoes[key].type === types.event)
+      const topicsMetadata = await admin.fetchTopicMetadata({ topics })
+      const maxPartitions = Math.max(...topicsMetadata.topics.map(t => t.partitions.length))
+      if (maxPartitions > group.members.length) {
+        console.warn(`There are more partitions (${maxPartitions}) than members (${group.members.length}) in the group ${consumerGroupId}`)
+        return true
+      }
+    }
 
     config.producer = kafka.producer(options.producer)
-    config.consumer = kafka.consumer(options.consumer)
-
-    await config.producer.connect()
-    await config.consumer.connect()
-
-    for (const topic in options.echoes) {
-      const echo = options.echoes[topic]
+    const consumers = {}
+    for (const [topic, echo] of Object.entries(options.echoes)) {
       if (echo.type !== types.event) continue
+      const consumerId = echo.consumerId ? `${options.consumer.groupId}-${echo.consumerId}` : options.consumer.groupId
+      if (!consumers[consumerId]) consumers[consumerId] = []
+      consumers[consumerId].push(topic)
+    }
 
-      await config.consumer.subscribe({
-        topic,
-        fromBeginning: options.readTopicsFromBeginning || false,
+    console.info('Consumers:', Object.keys(consumers))
+
+    const joinConsumerGroup = async (consumer, topics) => {
+      await consumer.connect()
+      await consumer.subscribe({ topics })
+      config.consumer.run({
+        eachMessage: async params => {
+          const echo = options.echoes[params.topic]
+          if (!echo) return
+          if (echo.type !== types.event) return
+          let intervalsCount = 0
+          const interval = setInterval(async () => {
+            await params.heartbeat().catch(error => {
+              console.warn('Echoes: Error sending heartbeat:', error)
+            })
+            intervalsCount++
+            if (intervalsCount % 10 === 0) {
+              console.warn(`Echoes: Event ${params.topic} is taking too long to process: ${intervalsCount * HEARTBEAT_INTERVAL_SECONDS}s`)
+            }
+          }, HEARTBEAT_INTERVAL_SECONDS * 1000)
+          await echo.onMessage(params).catch(error => {
+            clearInterval(interval)
+            throw error
+          })
+          clearInterval(interval)
+        },
       })
     }
 
-    config.consumer.run({
-      eachMessage: async params => {
-        const echo = options.echoes[params.topic]
-        if (!echo) return
-        if (echo.type !== types.event) return
-        let intervalsCount = 0
+
+    await config.producer.connect()
+
+    for (const [consumerId, topics] of Object.entries(consumers)) {
+      console.info(`Creating consumer ${consumerId} for topics ${topics}`)
+      const consumer = kafka.consumer({ groupId: consumerId })
+      if (await checkConsumerGroup(consumerId)) {
+        console.info(`Joining consumer group inmediately ${consumerId}`)
+        await joinConsumerGroup(consumer, topics)
+      } else {
+        console.info(`The consumer group has enough members, waiting to join ${consumerId}`)
         const interval = setInterval(async () => {
-          await params.heartbeat().catch(error => {
-            console.warn('Echoes: Error sending heartbeat:', error)
-          })
-          intervalsCount++
-          if (intervalsCount % 10 === 0) {
-            console.warn(`Echoes: Event ${params.topic} is taking too long to process: ${intervalsCount * HEARTBEAT_INTERVAL_SECONDS}s`)
+          if (await checkConsumerGroup(consumerId)) {
+            console.info(`Joining consumer group after checking ${consumerId}`)
+            await joinConsumerGroup(consumer, topics)
+            clearInterval(interval)
           }
-        }, HEARTBEAT_INTERVAL_SECONDS * 1000)
-        await echo.onMessage(params).catch(error => {
-          clearInterval(interval)
-          throw error
-        })
-        clearInterval(interval)
-      },
-    })
+        }, 5000)
+      }
+    }
+
+
   }
   if (options.requests) {
     config.requests = options.requests


### PR DESCRIPTION
Actualización de echoes que corrige varios problemas y expande funcionalidades:

# Heartbeat automático:
Para evitar abandonar mensajes de larga duración, se añade un heartbeat automático que envuelve los eventos. Además notifica con un log para detectar eventos de larga duración. En general echoes no debiese ser usado para procesar eventos lentos, por lo que el log es para detectarlos con facilidad. 

# Acceso condicionado al Consumer Group
Cuando una nueva instancia inicializa echoes ahora decidirá si ingresar o no al "consumer group". 
En servicio que tienen demasiadas instancias, en especial aquellas que tienen más instancias de las que kafka podría asignar particiones, el ingreso de nuevas instancias genera "re-joins" constantes que ralentizan el procesamiento de mensajes. 
Ahora las maquinas que detecten que un "consumer group" tiene más miembros que particiones, quedará a la espera, revisando cada 30 segundos `CHECK_JOIN_CONSUMER_INTERVAL_SECONDS`. 
Se puede configurar para que sean más o menos con `membersToPartitionsRatio`, por defecto es 1. Es decir igual cantidad de miembros que particiones. 

Cómo ejemplo, si pusieramos el `membersToPartitionsRatio` cómo 0.5 significaría que cómo mucho aceptaríamos la mitad de miembros que particiones. Obligan a los miembros a procesar al menos 2 particiones en paralelo. 

# Concurrencia
La implementación de echoes hasta ahora solo permitía procesar una partición por miembro. 
Ahora por defecto procesará hasta 4  `DEFAULT_PARTITIONS_CONSUMED_CONCURRENTLY` modificable con `partitionsConsumedConcurrently`. Esto obviamente queda limitado a que el grupo de maquinas esté consumiendo más de un tópico o un tópico con múltiples particiones. 

# Reintentos y Dead Letter
Se añade la función de Reintentos y Dead Letter Queue. Por defecto si un mensaje falla en `echoes` el mensaje no permitirá avanzar la partición a la que pertenece y será re-enviado a otros miembros hasta que sea procesado. Este funcionamiento es suficiente cuando el evento falla con poca frecuencia y que se recuperan con facilidad. 
Pero en caso de errores no recuperables estos casos detienen por completo el procesamiento de una partición. Si un tópico solo tiene una partición, detiene todo su consumo.

Para casos donde los errores son aceptables se añade la opción de envíar los eventos fallidos a una "Dead Letter Queue".
Una DLQ no es más que un tópico donde se almacenarán los eventos fallidos para poder continuar procesando el resto. 
Por defecto el tópico de DLQ es el nombre del tópico original con `DLQ-` como prefijo. 
Podemos suscribirnos a este tópico para procesar, o bien dejarlo para analitica posterior. 

Para activar DLQ se debe definir `attemptsBeforeDeadLetter`, 0 indica que ante cualquier falla el evento irá directo a la DLQ. Números mayores a 0 generan "reintentos" pero sin bloquear el tópico, ya que lo que se hará es consumir el mensaje y "re-ingresar" una copia del mensaje al final de cola. Una vea consumido los re-intentos el mensaje se irá a la DLQ.
Para evitar enviar un mensaje a la DLQ  basta manejar el error. El número de re-intentos viene en las cabeceras del mensaje.

# Detener servicios
Se añade una función para detener los servicios. Útil para usar en "graceful shutdown", permite que las maquinas se salgan de los consumer group ordenadamente de forma que Kafka detecta con mayor facilidad el estado real de grupo. 