### PR TITLE
feat(pulse): versioned per-event ordering and efficient recovery

### DIFF
--- a/.changeset/calm-events-listen.md
+++ b/.changeset/calm-events-listen.md
@@ -1,0 +1,5 @@
+---
+'@orion-js/echoes': patch
+---
+
+Allow Pulse ordering to be configured per Echoes event listener with `ordered`, overriding the global subscription default for that topic.

--- a/.changeset/calm-events-listen.md
+++ b/.changeset/calm-events-listen.md
@@ -3,4 +3,4 @@
 '@orion-js/pulse': patch
 ---
 
-Allow Pulse ordering to be configured per Echoes event listener with `ordered`, overriding the global subscription default for that topic. Pulse subscriptions now default to unordered delivery and support integer `configVersion` values so higher-version persisted settings win safely across deployments.
+Allow Pulse ordering to be configured per Echoes event listener with `ordered`, overriding the global subscription default for that topic. Pulse subscriptions now default to unordered delivery and support integer `configVersion` values so higher-version persisted settings win safely across deployments. Runtime recovery is also scheduled independently from backlog processing and uses partial-indexed repair markers instead of repeatedly scanning healthy deliveries.

--- a/.changeset/calm-events-listen.md
+++ b/.changeset/calm-events-listen.md
@@ -1,5 +1,6 @@
 ---
 '@orion-js/echoes': patch
+'@orion-js/pulse': patch
 ---
 
-Allow Pulse ordering to be configured per Echoes event listener with `ordered`, overriding the global subscription default for that topic.
+Allow Pulse ordering to be configured per Echoes event listener with `ordered`, overriding the global subscription default for that topic. Pulse subscriptions now default to unordered delivery.

--- a/.changeset/calm-events-listen.md
+++ b/.changeset/calm-events-listen.md
@@ -3,4 +3,4 @@
 '@orion-js/pulse': patch
 ---
 
-Allow Pulse ordering to be configured per Echoes event listener with `ordered`, overriding the global subscription default for that topic. Pulse subscriptions now default to unordered delivery and support integer `configVersion` values so higher-version persisted settings win safely across deployments. Runtime recovery is also scheduled independently from backlog processing and uses partial-indexed repair markers instead of repeatedly scanning healthy deliveries.
+Allow Pulse ordering to be configured per Echoes event listener with `ordered`, overriding the global subscription default for that topic. Pulse subscriptions now default to unordered delivery and support integer `configVersion` values so higher-version persisted settings win safely across deployments. Runtime recovery is also scheduled independently from backlog processing and uses partial-indexed repair markers instead of repeatedly scanning healthy deliveries. The discovery leader periodically removes successful deliveries after their persisted sequenced or legacy cursor has passed them and retention has been applied.

--- a/.changeset/calm-events-listen.md
+++ b/.changeset/calm-events-listen.md
@@ -3,4 +3,4 @@
 '@orion-js/pulse': patch
 ---
 
-Allow Pulse ordering to be configured per Echoes event listener with `ordered`, overriding the global subscription default for that topic. Pulse subscriptions now default to unordered delivery.
+Allow Pulse ordering to be configured per Echoes event listener with `ordered`, overriding the global subscription default for that topic. Pulse subscriptions now default to unordered delivery and support integer `configVersion` values so higher-version persisted settings win safely across deployments.

--- a/docs/blog/pulse-unordered-versioned-subscriptions.mdx
+++ b/docs/blog/pulse-unordered-versioned-subscriptions.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Pulse is unordered by default'
-description: 'Configure ordering per Echoes listener and safely evolve persisted subscriptions with configVersion'
+title: 'Pulse concurrency and efficient recovery'
+description: 'Configure ordering per Echoes listener, evolve subscriptions safely, and reduce MongoDB recovery load'
 ---
 
 Pulse subscriptions now favor concurrency by default. New topics use unordered delivery unless a
@@ -82,6 +82,62 @@ the highest persisted version as replicas refresh their subscription documents.
 That short transition is appropriate when intentionally switching between ordered and concurrent
 processing. If an application requires a hard boundary with no overlap at all, drain or stop its
 consumer replicas before deploying the higher version.
+
+## Recovery no longer runs in the backlog hot loop
+
+Pulse now schedules runtime maintenance independently from event discovery and execution:
+
+- Reconciliation normally runs every 30 seconds and reads only documents marked with
+  `needsReconciliation` through small partial indexes.
+- Expired attempts are checked near the next known lock deadline instead of on every coordinator
+  iteration.
+- Recovery fetches related deliveries and histories in bounded batches instead of issuing one
+  lookup for every delivery.
+
+The marker is written before a cross-collection transition and removed only after its dependent
+write succeeds. A process crash therefore leaves an indexed repair record without requiring Pulse
+to scan healthy `pending`, `success`, and `error` deliveries while a backlog is draining.
+
+## Completed delivery cleanup
+
+The discovery leader periodically removes up to 1,000 successful deliveries from a rotating set
+of topics. A delivery is eligible only when its persisted subscription cursor has reached that
+event. Pulse handles the MongoDB sequence cursor and the legacy `createdAt + eventId` cursor
+independently.
+
+When `historyRetentionMs` is enabled, cleanup also requires `delivery.expiresAt`. This field proves
+that retention was already applied to the delivery and its completed history before the delivery
+is removed. With `historyRetentionMs: null`, no `expiresAt` marker is required. Cleanup never reads
+the history collection and runs on its own 60-second cadence, outside the coordinator hot loop.
+
+## Production upgrade
+
+Upgrade services in two phases when changing an existing topic's ordering:
+
+1. Upgrade every replica to `@orion-js/pulse@4.5.4` and `@orion-js/echoes@4.5.3` without changing
+   the topic configuration. Existing subscriptions keep their persisted ordering.
+2. After all replicas run the new packages, deploy the intended `ordered` value with a higher
+   `configVersion`.
+
+For example, a legacy version-zero subscription can be changed after phase one with:
+
+```typescript
+@EchoEvent()
+orderCreated = createEchoEvent({
+  ordered: false,
+  configVersion: 1,
+  resolve: handleOrderCreated,
+})
+```
+
+Use the next integer if the topic already has a version. Deploying the package upgrade separately
+keeps old replicas that do not understand `configVersion` out of the configuration transition.
+
+Pulse creates and validates the new partial reconciliation indexes during startup. On a large
+MongoDB deployment, start with one canary replica, wait for `awaitConnection()` to complete, and
+check database CPU, disk queue, and index-build progress before rolling the remaining replicas.
+After rollout, the old repeated delivery-reconciliation aggregate shapes should disappear from
+Query Insights; marker lookups should examine only a small number of documents.
 
 ## Versioning rules
 

--- a/docs/blog/pulse-unordered-versioned-subscriptions.mdx
+++ b/docs/blog/pulse-unordered-versioned-subscriptions.mdx
@@ -1,0 +1,96 @@
+---
+title: 'Pulse is unordered by default'
+description: 'Configure ordering per Echoes listener and safely evolve persisted subscriptions with configVersion'
+---
+
+Pulse subscriptions now favor concurrency by default. New topics use unordered delivery unless a
+listener explicitly sets `ordered: true`, and Echoes can choose that behavior independently for
+each event listener.
+
+```typescript
+@Echoes()
+export class OrderEvents {
+  @EchoEvent()
+  orderCreated = createEchoEvent({
+    ordered: true,
+    configVersion: 1,
+    resolve: async params => {
+      await applyOrderTransition(params)
+    },
+  })
+
+  @EchoEvent()
+  analyticsRecorded = createEchoEvent({
+    resolve: async params => {
+      await recordAnalytics(params)
+    },
+  })
+}
+```
+
+`orderCreated` is serialized across every replica in its consumer group. `analyticsRecorded`
+inherits Pulse's unordered default and can use the available worker concurrency.
+
+## Why subscription configuration is persisted
+
+Pulse stores one subscription document for each `consumerGroup + topic`. That document contains
+the durable cursor as well as ordering, delivery, and retry settings. Persisting the settings keeps
+replicas consistent, but previously made intentional changes awkward: a new deployment with a
+different value failed because it did not match MongoDB.
+
+`configVersion` makes the desired change explicit. It is a non-negative integer, and the highest
+version wins:
+
+```typescript
+// Current production configuration
+await pulse.subscribe('order.created', handleOrder, {
+  ordered: true,
+  configVersion: 1,
+})
+
+// Later deployment: allow concurrent processing
+await pulse.subscribe('order.created', handleOrder, {
+  ordered: false,
+  configVersion: 2,
+})
+```
+
+The update uses an atomic comparison in MongoDB. Replicas still running version 1 cannot downgrade
+the subscription after version 2 wins. A second configuration that reuses version 2 with different
+settings fails fast, making accidental version reuse visible during startup.
+
+## Existing subscriptions
+
+Legacy subscription documents have no version and are treated as version zero. If code omits
+`ordered` for an existing topic, Pulse keeps the persisted value. This means upgrading does not
+silently turn an existing ordered topic into an unordered one.
+
+For a brand-new topic, omitting both fields creates an unordered version-zero subscription:
+
+```typescript
+await pulse.subscribe('image.requested', resizeImage)
+```
+
+To intentionally modify an existing topic, declare the new setting and increase its version.
+
+## What happens during deployment
+
+The change is deliberately lightweight: Pulse does not pause the topic or run a separate migration
+job. Callbacks that were already claimed finish with the previous behavior. New work converges on
+the highest persisted version as replicas refresh their subscription documents.
+
+That short transition is appropriate when intentionally switching between ordered and concurrent
+processing. If an application requires a hard boundary with no overlap at all, drain or stop its
+consumer replicas before deploying the higher version.
+
+## Versioning rules
+
+- Use non-negative integers and increase the number only when durable subscription settings change.
+- A higher version replaces a lower version atomically.
+- A lower version adopts the persisted winner and never downgrades it.
+- Different settings at the same version throw `PulseConfigurationError`.
+- Omitting the version means version zero.
+- `maxConcurrency` remains local to each process and is not part of the persisted configuration.
+
+See [Consuming events](/overview/other-modules/pulse/consuming) for the complete subscription API
+and [Echoes](/overview/controllers/echoes) for per-listener configuration.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -107,7 +107,12 @@
       },
       {
         "tab": "Blog",
-        "pages": ["blog/orionjs-4-5-migration", "blog/typescript-7", "blog/repl-command"]
+        "pages": [
+          "blog/pulse-unordered-versioned-subscriptions",
+          "blog/orionjs-4-5-migration",
+          "blog/typescript-7",
+          "blog/repl-command"
+        ]
       }
     ],
     "global": {

--- a/docs/overview/controllers/echoes.mdx
+++ b/docs/overview/controllers/echoes.mdx
@@ -122,6 +122,8 @@ processSomething = createEchoEvent({
   attemptsBeforeDeadLetter: 5,
   // Pulse only: overrides events.pulse.subscription.ordered for this topic
   ordered: true,
+  // Increase when changing persisted Pulse subscription settings
+  configVersion: 1,
   params: {
     // schema definition
   },
@@ -135,6 +137,24 @@ When `ordered` is omitted, the listener inherits `events.pulse.subscription.orde
 configured, Pulse defaults to unordered delivery. This lets ordered topics and concurrently
 processed topics share the same Echoes Pulse transport. Method listeners can set the same option
 directly with `@EchoEvent({ ordered: true })`.
+
+Pulse persists each `consumerGroup + topic` configuration. When changing `ordered`, increase the
+listener's integer `configVersion`:
+
+```typescript
+@EchoEvent()
+processSomething = createEchoEvent({
+  ordered: false,
+  configVersion: 2,
+  resolve: async params => {
+    // Events can now run concurrently.
+  },
+})
+```
+
+The highest version wins during a deploy, so an older replica cannot restore an earlier setting.
+Using the same version with different settings fails fast. Existing callbacks finish normally and
+new work converges on the winning configuration.
 
 ## Making Requests
 

--- a/docs/overview/controllers/echoes.mdx
+++ b/docs/overview/controllers/echoes.mdx
@@ -120,6 +120,8 @@ The `createEchoEvent()` function accepts options similar to `createEchoRequest()
 @EchoEvent()
 processSomething = createEchoEvent({
   attemptsBeforeDeadLetter: 5,
+  // Pulse only: overrides events.pulse.subscription.ordered for this topic
+  ordered: true,
   params: {
     // schema definition
   },
@@ -128,6 +130,10 @@ processSomething = createEchoEvent({
   }
 })
 ```
+
+When `ordered` is omitted, the listener inherits `events.pulse.subscription.ordered` (or Pulse's
+default). This lets ordered topics and concurrently processed topics share the same Echoes Pulse
+transport. Method listeners can set the same option directly with `@EchoEvent({ ordered: true })`.
 
 ## Making Requests
 

--- a/docs/overview/controllers/echoes.mdx
+++ b/docs/overview/controllers/echoes.mdx
@@ -131,9 +131,10 @@ processSomething = createEchoEvent({
 })
 ```
 
-When `ordered` is omitted, the listener inherits `events.pulse.subscription.ordered` (or Pulse's
-default). This lets ordered topics and concurrently processed topics share the same Echoes Pulse
-transport. Method listeners can set the same option directly with `@EchoEvent({ ordered: true })`.
+When `ordered` is omitted, the listener inherits `events.pulse.subscription.ordered`. If neither is
+configured, Pulse defaults to unordered delivery. This lets ordered topics and concurrently
+processed topics share the same Echoes Pulse transport. Method listeners can set the same option
+directly with `@EchoEvent({ ordered: true })`.
 
 ## Making Requests
 

--- a/docs/overview/other-modules/pulse/api-reference.mdx
+++ b/docs/overview/other-modules/pulse/api-reference.mdx
@@ -90,6 +90,7 @@ const subscription = await pulse.subscribe(topic, handler, options)
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `ordered` | `boolean` | `false` | Set to true to serialize this group and topic across all replicas. |
+| `configVersion` | `number` | `0` | Non-negative integer for persisted settings. Higher versions win. |
 | `offsetReset` | `'latest' \| 'earliest'` | `latest` | Starting point when the durable subscription is first created. |
 | `delivery` | `'at-least-once' \| 'at-most-once'` | `at-least-once` | Retry semantics. |
 | `maxRetries` | `number` | `3` | Retries after the initial attempt. Forced to zero for at-most-once. |
@@ -107,7 +108,8 @@ type PulseEventHandler<TTopic extends string, TData> = (
 
 `PulseReceivedEvent` contains every published event field plus `consumerGroup` and the one-based `attempt` number.
 
-The returned subscription contains the resolved options and an idempotent asynchronous `unsubscribe()` method.
+The returned subscription contains the resolved options, including the winning `configVersion`,
+and an idempotent asynchronous `unsubscribe()` method.
 
 ## `pulse.getSubscriptions()`
 

--- a/docs/overview/other-modules/pulse/api-reference.mdx
+++ b/docs/overview/other-modules/pulse/api-reference.mdx
@@ -89,7 +89,7 @@ const subscription = await pulse.subscribe(topic, handler, options)
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `ordered` | `boolean` | `true` | Serialize this group and topic across all replicas. |
+| `ordered` | `boolean` | `false` | Set to true to serialize this group and topic across all replicas. |
 | `offsetReset` | `'latest' \| 'earliest'` | `latest` | Starting point when the durable subscription is first created. |
 | `delivery` | `'at-least-once' \| 'at-most-once'` | `at-least-once` | Retry semantics. |
 | `maxRetries` | `number` | `3` | Retries after the initial attempt. Forced to zero for at-most-once. |

--- a/docs/overview/other-modules/pulse/consuming.mdx
+++ b/docs/overview/other-modules/pulse/consuming.mdx
@@ -54,6 +54,7 @@ const pulse = connect<CommerceEvents>({
 
 await pulse.subscribe('order.created', handleOrder, {
   ordered: true,
+  configVersion: 1,
   delivery: 'at-least-once',
 })
 ```
@@ -117,6 +118,34 @@ await pulse.subscribe('image.requested', resizeImage, {
 
 `maxConcurrency` limits running handlers for that topic in the current process. Total concurrency also depends on `workerCount` and the number of replicas. It is a local execution limit and is not part of the durable subscription configuration.
 
+## Changing persisted configuration
+
+Pulse stores subscription settings by `consumerGroup + topic`. Use a non-negative integer
+`configVersion` whenever those settings change:
+
+```typescript
+// Previous deployment
+await pulse.subscribe('order.created', handleOrder, {
+  ordered: true,
+  configVersion: 1,
+})
+
+// New deployment
+await pulse.subscribe('order.created', handleOrder, {
+  ordered: false,
+  configVersion: 2,
+})
+```
+
+The highest version wins atomically. A replica with a lower version adopts the persisted winner
+instead of reverting it. Reusing one version with different settings throws
+`PulseConfigurationError`.
+
+Legacy subscriptions and omitted versions are version zero. When `ordered` is omitted for an
+existing subscription, Pulse preserves its persisted value; a new subscription defaults to
+unordered delivery. Already-running callbacks finish normally during a version change, while new
+work converges on the winning configuration.
+
 ## Retries
 
 The default mode is at-least-once with an initial attempt and three retries:
@@ -164,6 +193,7 @@ This means one handler attempt per delivery. It does not make external side effe
 
 Pulse persists these options for each `consumerGroup + topic`:
 
+- `configVersion`
 - `ordered`
 - `offsetReset`
 - `delivery`
@@ -171,7 +201,9 @@ Pulse persists these options for each `consumerGroup + topic`:
 - `retryDelayMs`
 - `retryBackoffMultiplier`
 
-Every replica must provide matching values. A mismatch throws `PulseConfigurationError` instead of silently changing delivery semantics. `maxConcurrency` remains local to each process.
+Every replica using the same version must provide matching values. A mismatch throws
+`PulseConfigurationError`. Higher versions replace lower ones; lower versions use the persisted
+winner. `maxConcurrency` remains local to each process.
 
 ## Inspect and stop subscriptions
 

--- a/docs/overview/other-modules/pulse/consuming.mdx
+++ b/docs/overview/other-modules/pulse/consuming.mdx
@@ -87,7 +87,7 @@ The cursor is saved after Pulse materializes deliveries. Restarting a service re
 
 ## Ordered delivery
 
-Ordered mode is the default:
+Ordered delivery is opt-in:
 
 ```typescript
 await pulse.subscribe('order.created', handleOrder, {
@@ -106,7 +106,7 @@ This provides processing order, not a transaction that spans the handler and ext
 
 ## Concurrent delivery
 
-Use concurrent mode for independent events:
+Concurrent delivery is the default. Omit `ordered` or set it to `false` for independent events:
 
 ```typescript
 await pulse.subscribe('image.requested', resizeImage, {

--- a/docs/overview/other-modules/pulse/reliability.mdx
+++ b/docs/overview/other-modules/pulse/reliability.mdx
@@ -183,7 +183,7 @@ const pulse = connect({
 })
 ```
 
-Keep the default for typical ordered consumers. Increase it only after observing pool contention or
+Keep the default for typical consumers. Increase it only after observing pool contention or
 when using higher worker and handler concurrency.
 
 ## Polling

--- a/packages/echoes/src/echo/index.ts
+++ b/packages/echoes/src/echo/index.ts
@@ -55,6 +55,10 @@ const echo = function createNewEcho<
     returns: options.returns,
     attemptsBeforeDeadLetter:
       options.type === 'event' ? options.attemptsBeforeDeadLetter : undefined,
+    ordered:
+      options.type === 'event'
+        ? (options as EchoEventConfig<TParamsSchema, TReturnsSchema>).ordered
+        : undefined,
     resolve,
     onEvent,
     onMessage: async (messageData: EchoesKafkaMessagePayload) => {

--- a/packages/echoes/src/echo/index.ts
+++ b/packages/echoes/src/echo/index.ts
@@ -59,6 +59,10 @@ const echo = function createNewEcho<
       options.type === 'event'
         ? (options as EchoEventConfig<TParamsSchema, TReturnsSchema>).ordered
         : undefined,
+    configVersion:
+      options.type === 'event'
+        ? (options as EchoEventConfig<TParamsSchema, TReturnsSchema>).configVersion
+        : undefined,
     resolve,
     onEvent,
     onMessage: async (messageData: EchoesKafkaMessagePayload) => {

--- a/packages/echoes/src/events/EventBus.test.ts
+++ b/packages/echoes/src/events/EventBus.test.ts
@@ -46,6 +46,7 @@ describe('Echoes EventBus', () => {
       echoes: {
         'order.created': createEchoEvent({
           attemptsBeforeDeadLetter: 4,
+          ordered: false,
           async resolve(params, context) {
             contexts.push({params, transport: context.transport})
           },
@@ -63,7 +64,7 @@ describe('Echoes EventBus', () => {
     expect(pulse.startOptions.consume).toBe(true)
     expect(pulse.startOptions.publish).toBe(false)
     expect(pulse.startOptions.subscriptions).toEqual([
-      {topic: 'order.created', attemptsBeforeDeadLetter: 4},
+      {topic: 'order.created', attemptsBeforeDeadLetter: 4, ordered: false},
     ])
 
     await kafka.emit('order.created', {orderId: 'kafka'})

--- a/packages/echoes/src/events/EventBus.test.ts
+++ b/packages/echoes/src/events/EventBus.test.ts
@@ -47,6 +47,7 @@ describe('Echoes EventBus', () => {
         'order.created': createEchoEvent({
           attemptsBeforeDeadLetter: 4,
           ordered: false,
+          configVersion: 2,
           async resolve(params, context) {
             contexts.push({params, transport: context.transport})
           },
@@ -64,7 +65,12 @@ describe('Echoes EventBus', () => {
     expect(pulse.startOptions.consume).toBe(true)
     expect(pulse.startOptions.publish).toBe(false)
     expect(pulse.startOptions.subscriptions).toEqual([
-      {topic: 'order.created', attemptsBeforeDeadLetter: 4, ordered: false},
+      {
+        topic: 'order.created',
+        attemptsBeforeDeadLetter: 4,
+        ordered: false,
+        configVersion: 2,
+      },
     ])
 
     await kafka.emit('order.created', {orderId: 'kafka'})

--- a/packages/echoes/src/events/EventBus.ts
+++ b/packages/echoes/src/events/EventBus.ts
@@ -48,6 +48,7 @@ export default class EventBus {
         topic,
         attemptsBeforeDeadLetter: echo.attemptsBeforeDeadLetter,
         ordered: echo.ordered,
+        configVersion: echo.configVersion,
       }))
 
     try {

--- a/packages/echoes/src/events/EventBus.ts
+++ b/packages/echoes/src/events/EventBus.ts
@@ -47,6 +47,7 @@ export default class EventBus {
       .map(([topic, echo]) => ({
         topic,
         attemptsBeforeDeadLetter: echo.attemptsBeforeDeadLetter,
+        ordered: echo.ordered,
       }))
 
     try {

--- a/packages/echoes/src/events/EventTransport.ts
+++ b/packages/echoes/src/events/EventTransport.ts
@@ -3,6 +3,7 @@ import type {EchoesEventTransportName, EchoesReceivedEvent, PublishOptions} from
 export interface EventSubscriptionDefinition {
   topic: string
   attemptsBeforeDeadLetter?: number
+  ordered?: boolean
 }
 
 export interface EventTransportStartOptions {

--- a/packages/echoes/src/events/EventTransport.ts
+++ b/packages/echoes/src/events/EventTransport.ts
@@ -4,6 +4,7 @@ export interface EventSubscriptionDefinition {
   topic: string
   attemptsBeforeDeadLetter?: number
   ordered?: boolean
+  configVersion?: number
 }
 
 export interface EventTransportStartOptions {

--- a/packages/echoes/src/events/PulseManager.test.ts
+++ b/packages/echoes/src/events/PulseManager.test.ts
@@ -1,4 +1,5 @@
 import {expect, it} from 'bun:test'
+import {MongoClient} from 'mongodb'
 import {MongoMemoryServer} from 'mongodb-memory-server'
 import {createEchoEvent} from '../echo'
 import publish from '../publish'
@@ -24,9 +25,13 @@ it('publishes and consumes Echoes events through Pulse', async () => {
   const options: EchoesOptions = {
     echoes: {
       'order.created': createEchoEvent({
+        ordered: false,
         async resolve(params, context) {
           contexts.push({params, context})
         },
+      }),
+      'invoice.created': createEchoEvent({
+        async resolve() {},
       }),
     },
     events: {
@@ -38,6 +43,7 @@ it('publishes and consumes Echoes events through Pulse', async () => {
         lockTimeoutMs: 1000,
         discoveryLockTimeoutMs: 500,
         subscription: {
+          ordered: true,
           offsetReset: 'latest',
         },
       },
@@ -48,6 +54,21 @@ it('publishes and consumes Echoes events through Pulse', async () => {
 
   try {
     await startService(options)
+    const mongoClient = new MongoClient(mongo.getUri('echoes'))
+    await mongoClient.connect()
+    const subscriptions = await mongoClient
+      .db('echoes')
+      .collection('orionjs.pulse.subscriptions')
+      .find({}, {projection: {_id: 0, topic: 1, ordered: 1}})
+      .sort({topic: 1})
+      .toArray()
+    await mongoClient.close()
+
+    expect(subscriptions).toEqual([
+      {topic: 'invoice.created', ordered: true},
+      {topic: 'order.created', ordered: false},
+    ])
+
     const published = await publish({
       topic: 'order.created',
       params: {orderId: '123'},

--- a/packages/echoes/src/events/PulseManager.test.ts
+++ b/packages/echoes/src/events/PulseManager.test.ts
@@ -26,6 +26,7 @@ it('publishes and consumes Echoes events through Pulse', async () => {
     echoes: {
       'order.created': createEchoEvent({
         ordered: true,
+        configVersion: 2,
         async resolve(params, context) {
           contexts.push({params, context})
         },
@@ -58,14 +59,14 @@ it('publishes and consumes Echoes events through Pulse', async () => {
     const subscriptions = await mongoClient
       .db('echoes')
       .collection('orionjs.pulse.subscriptions')
-      .find({}, {projection: {_id: 0, topic: 1, ordered: 1}})
+      .find({}, {projection: {_id: 0, topic: 1, ordered: 1, configVersion: 1}})
       .sort({topic: 1})
       .toArray()
     await mongoClient.close()
 
     expect(subscriptions).toEqual([
-      {topic: 'invoice.created', ordered: false},
-      {topic: 'order.created', ordered: true},
+      {topic: 'invoice.created', ordered: false, configVersion: 0},
+      {topic: 'order.created', ordered: true, configVersion: 2},
     ])
 
     const published = await publish({

--- a/packages/echoes/src/events/PulseManager.test.ts
+++ b/packages/echoes/src/events/PulseManager.test.ts
@@ -25,7 +25,7 @@ it('publishes and consumes Echoes events through Pulse', async () => {
   const options: EchoesOptions = {
     echoes: {
       'order.created': createEchoEvent({
-        ordered: false,
+        ordered: true,
         async resolve(params, context) {
           contexts.push({params, context})
         },
@@ -43,7 +43,6 @@ it('publishes and consumes Echoes events through Pulse', async () => {
         lockTimeoutMs: 1000,
         discoveryLockTimeoutMs: 500,
         subscription: {
-          ordered: true,
           offsetReset: 'latest',
         },
       },
@@ -65,8 +64,8 @@ it('publishes and consumes Echoes events through Pulse', async () => {
     await mongoClient.close()
 
     expect(subscriptions).toEqual([
-      {topic: 'invoice.created', ordered: true},
-      {topic: 'order.created', ordered: false},
+      {topic: 'invoice.created', ordered: false},
+      {topic: 'order.created', ordered: true},
     ])
 
     const published = await publish({

--- a/packages/echoes/src/events/PulseManager.ts
+++ b/packages/echoes/src/events/PulseManager.ts
@@ -80,6 +80,7 @@ export default class PulseManager implements EventTransport {
     return {
       ...defaults,
       ...(definition.ordered === undefined ? {} : {ordered: definition.ordered}),
+      ...(definition.configVersion === undefined ? {} : {configVersion: definition.configVersion}),
       ...(definition.attemptsBeforeDeadLetter === undefined
         ? {}
         : {maxRetries: definition.attemptsBeforeDeadLetter}),

--- a/packages/echoes/src/events/PulseManager.ts
+++ b/packages/echoes/src/events/PulseManager.ts
@@ -51,7 +51,7 @@ export default class PulseManager implements EventTransport {
         this.pulse.subscribe(
           definition.topic,
           event => options.onEvent(this.createReceivedEvent(event)),
-          this.getSubscribeOptions(subscription, definition.attemptsBeforeDeadLetter),
+          this.getSubscribeOptions(subscription, definition),
         ),
       ),
     )
@@ -75,11 +75,14 @@ export default class PulseManager implements EventTransport {
 
   private getSubscribeOptions(
     defaults: PulseSubscribeOptions = {},
-    attemptsBeforeDeadLetter?: number,
+    definition: EventTransportStartOptions['subscriptions'][number],
   ): PulseSubscribeOptions {
     return {
       ...defaults,
-      ...(attemptsBeforeDeadLetter === undefined ? {} : {maxRetries: attemptsBeforeDeadLetter}),
+      ...(definition.ordered === undefined ? {} : {ordered: definition.ordered}),
+      ...(definition.attemptsBeforeDeadLetter === undefined
+        ? {}
+        : {maxRetries: definition.attemptsBeforeDeadLetter}),
     }
   }
 

--- a/packages/echoes/src/service/index.test.ts
+++ b/packages/echoes/src/service/index.test.ts
@@ -11,7 +11,7 @@ describe('Echoes with service injections', () => {
         return 1
       }
 
-      @EchoEvent({ordered: false})
+      @EchoEvent({ordered: false, configVersion: 2})
       async echoEvent() {
         return 2
       }
@@ -23,6 +23,7 @@ describe('Echoes with service injections', () => {
     expect(typeof echoes.echo.onRequest).toBe('function')
     expect(echoes.echoEvent.type).toBe('event')
     expect(echoes.echoEvent.ordered).toBe(false)
+    expect(echoes.echoEvent.configVersion).toBe(2)
     expect(typeof echoes.echoEvent.resolve).toBe('function')
   })
 

--- a/packages/echoes/src/service/index.test.ts
+++ b/packages/echoes/src/service/index.test.ts
@@ -11,7 +11,7 @@ describe('Echoes with service injections', () => {
         return 1
       }
 
-      @EchoEvent()
+      @EchoEvent({ordered: false})
       async echoEvent() {
         return 2
       }
@@ -22,6 +22,7 @@ describe('Echoes with service injections', () => {
     expect(echoes.echo.type).toBe('request')
     expect(typeof echoes.echo.onRequest).toBe('function')
     expect(echoes.echoEvent.type).toBe('event')
+    expect(echoes.echoEvent.ordered).toBe(false)
     expect(typeof echoes.echoEvent.resolve).toBe('function')
   })
 

--- a/packages/echoes/src/types.ts
+++ b/packages/echoes/src/types.ts
@@ -25,6 +25,10 @@ export interface EchoEventConfig<
    * When neither value is configured, Pulse defaults to false.
    */
   ordered?: boolean
+  /**
+   * Pulse only. Integer version for persisted subscription settings. Higher versions win.
+   */
+  configVersion?: number
   resolve(
     params?: InferEchoesSchema<TParamsSchema>,
     context?: any,
@@ -51,6 +55,7 @@ export type EchoType<
   returns?: TReturnsSchema
   attemptsBeforeDeadLetter?: number
   ordered?: boolean
+  configVersion?: number
   type: TEchoType
   resolve(
     params?: InferEchoesSchema<TParamsSchema>,
@@ -223,6 +228,7 @@ export interface EchoesPulseEventsConfig {
    */
   subscription?: {
     ordered?: boolean
+    configVersion?: number
     offsetReset?: 'latest' | 'earliest'
     delivery?: 'at-least-once' | 'at-most-once'
     maxRetries?: number

--- a/packages/echoes/src/types.ts
+++ b/packages/echoes/src/types.ts
@@ -20,6 +20,10 @@ export interface EchoEventConfig<
 > {
   params?: TParamsSchema
   returns?: TReturnsSchema
+  /**
+   * Pulse only. Overrides events.pulse.subscription.ordered for this topic listener.
+   */
+  ordered?: boolean
   resolve(
     params?: InferEchoesSchema<TParamsSchema>,
     context?: any,
@@ -45,6 +49,7 @@ export type EchoType<
   params?: TParamsSchema
   returns?: TReturnsSchema
   attemptsBeforeDeadLetter?: number
+  ordered?: boolean
   type: TEchoType
   resolve(
     params?: InferEchoesSchema<TParamsSchema>,
@@ -212,7 +217,8 @@ export interface EchoesPulseEventsConfig {
   onError?: (error: Error) => void
   /**
    * Subscription defaults used by every Echoes event handled through Pulse.
-   * attemptsBeforeDeadLetter overrides maxRetries per event when configured.
+   * Event-level ordered and attemptsBeforeDeadLetter override ordered and maxRetries
+   * respectively when configured.
    */
   subscription?: {
     ordered?: boolean

--- a/packages/echoes/src/types.ts
+++ b/packages/echoes/src/types.ts
@@ -22,6 +22,7 @@ export interface EchoEventConfig<
   returns?: TReturnsSchema
   /**
    * Pulse only. Overrides events.pulse.subscription.ordered for this topic listener.
+   * When neither value is configured, Pulse defaults to false.
    */
   ordered?: boolean
   resolve(

--- a/packages/pulse/README.md
+++ b/packages/pulse/README.md
@@ -41,6 +41,7 @@ await pulse.subscribe(
   },
   {
     ordered: true,
+    configVersion: 1,
     offsetReset: 'latest',
     delivery: 'at-least-once',
     maxRetries: 3,
@@ -166,6 +167,7 @@ delivery row has already expired, at-least-once semantics allow the retained eve
 | Option | Default | Description |
 | --- | --- | --- |
 | `ordered` | `false` | Set to true to prevent callbacks from overlapping for this consumer group and topic. |
+| `configVersion` | `0` | Integer version for persisted settings. A higher version atomically replaces a lower one. |
 | `offsetReset` | `latest` | First subscription starts at `latest` or the earliest retained event. |
 | `delivery` | `at-least-once` | Can also be `at-most-once`. |
 | `maxRetries` | 3 | Retries after the initial attempt. At-most-once always uses zero. |
@@ -173,7 +175,12 @@ delivery row has already expired, at-least-once semantics allow the retained eve
 | `retryBackoffMultiplier` | 2 | Produces default delays of 1, 2, and 4 seconds. |
 | `maxConcurrency` | worker count | Per-process topic concurrency when `ordered` is false. |
 
-Subscription behavior is persisted by `consumerGroup + topic`. Replicas must declare matching ordering, offset, delivery, and retry options. Calling `unsubscribe()` stops local processing but preserves the durable offset; subscribing again resumes from it.
+Subscription behavior is persisted by `consumerGroup + topic`. Replicas at the same
+`configVersion` must declare matching ordering, offset, delivery, and retry options. A higher
+version atomically replaces a lower one; a lower version adopts the persisted winner and cannot
+downgrade it. Legacy documents and omitted versions are treated as version zero. Calling
+`unsubscribe()` stops local processing but preserves the durable offset; subscribing again resumes
+from it.
 
 ## Delivery and recovery
 

--- a/packages/pulse/README.md
+++ b/packages/pulse/README.md
@@ -165,7 +165,7 @@ delivery row has already expired, at-least-once semantics allow the retained eve
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `ordered` | `true` | Prevent callbacks from overlapping for this consumer group and topic. |
+| `ordered` | `false` | Set to true to prevent callbacks from overlapping for this consumer group and topic. |
 | `offsetReset` | `latest` | First subscription starts at `latest` or the earliest retained event. |
 | `delivery` | `at-least-once` | Can also be `at-most-once`. |
 | `maxRetries` | 3 | Retries after the initial attempt. At-most-once always uses zero. |

--- a/packages/pulse/README.md
+++ b/packages/pulse/README.md
@@ -230,6 +230,12 @@ seconds unless a full batch of 25 repairs remains. Cross-collection writes tempo
 `needsReconciliation`; partial indexes keep these recovery queries proportional to incomplete
 writes instead of the total number of deliveries or history records.
 
+The discovery leader also removes completed `success` deliveries in periodic batches after the
+persisted sequenced or legacy cursor has reached them. When retention is enabled, cleanup requires
+the delivery's `expiresAt` marker so history retention is known to have been applied first. With
+`historyRetentionMs: null`, cleanup does not require that marker. This maintenance path never reads
+the history collection.
+
 `changeStreams` is not a supported connection option. Remove it from existing configurations
 before upgrading. Pulse rejects the legacy field at startup, including `changeStreams: 'disabled'`,
 so a stale deployment cannot suggest that a Change Stream mode is still available.

--- a/packages/pulse/README.md
+++ b/packages/pulse/README.md
@@ -124,7 +124,7 @@ does not cache results.
 | `collectionPrefix` | `orionjs.pulse` | Prefix for the four Pulse collections. |
 | `eventRetentionMs` | 7 days | Event retention, or `null` to disable expiration. |
 | `historyRetentionMs` | 7 days | Completed delivery/history retention, or `null`. |
-| `pollIntervalMs` | 3000 | Polling and reconciliation interval. |
+| `pollIntervalMs` | 3000 | Idle coordinator polling interval. |
 | `workerCount` | 4 | Maximum concurrent handler executions in this process. |
 | `maxPoolSize` | 5 | Maximum MongoDB application connections per server for this Pulse client. |
 | `lockTimeoutMs` | 30000 | Distributed lease duration. Active handlers renew it automatically. |
@@ -220,9 +220,15 @@ for (const attempt of result.records) {
 
 ## Polling
 
-Polling and reconciliation are the only discovery and recovery mechanisms. Pulse works with
-standalone MongoDB, replica sets, and sharded clusters without opening Change Streams. Tune
-`pollIntervalMs` to balance idle query volume and delivery latency.
+Polling is the discovery mechanism, and indexed reconciliation markers provide crash recovery.
+Pulse works with standalone MongoDB, replica sets, and sharded clusters without opening Change
+Streams. Tune `pollIntervalMs` to balance idle query volume and delivery latency.
+
+Maintenance does not run on every coordinator iteration while a backlog is draining. Expired
+attempts are checked near the next known lock deadline, and reconciliation runs at most every 30
+seconds unless a full batch of 25 repairs remains. Cross-collection writes temporarily set
+`needsReconciliation`; partial indexes keep these recovery queries proportional to incomplete
+writes instead of the total number of deliveries or history records.
 
 `changeStreams` is not a supported connection option. Remove it from existing configurations
 before upgrading. Pulse rejects the legacy field at startup, including `changeStreams: 'disabled'`,

--- a/packages/pulse/src/Pulse.test.ts
+++ b/packages/pulse/src/Pulse.test.ts
@@ -50,6 +50,7 @@ function getRuntimeState(pulse: Pulse<any>) {
     discoveryRefreshAt: number
     nextReapAt: number
     nextReconciliationAt: number
+    nextDeliveryCleanupAt: number
     localSubscriptions: Map<string, {running: number}>
     running: boolean
     collections: {
@@ -66,6 +67,7 @@ function getRuntimeState(pulse: Pulse<any>) {
     claimExecutions(capacity: number): Promise<unknown[]>
     reapExpiredAttempts(topics: string[]): Promise<number>
     reconcileDeliveries(topics: string[]): Promise<number>
+    cleanupSuccessfulDeliveries(topics: string[]): Promise<number>
   }
 }
 
@@ -549,6 +551,7 @@ describe('Pulse persistence', () => {
 
     let reapCalls = 0
     let reconciliationCalls = 0
+    let cleanupCalls = 0
     runtime.reapExpiredAttempts = async () => {
       reapCalls++
       runtime.nextReapAt = Date.now() + 60_000
@@ -559,14 +562,216 @@ describe('Pulse persistence', () => {
       runtime.nextReconciliationAt = Date.now() + 60_000
       return 0
     }
+    runtime.cleanupSuccessfulDeliveries = async () => {
+      cleanupCalls++
+      runtime.nextDeliveryCleanupAt = Date.now() + 60_000
+      return 0
+    }
     runtime.nextReapAt = 0
     runtime.nextReconciliationAt = 0
+    runtime.nextDeliveryCleanupAt = 0
 
     await runtime.coordinateOnce()
     await Promise.all(Array.from({length: 10}, () => runtime.coordinateOnce()))
 
     expect(reapCalls).toBe(1)
     expect(reconciliationCalls).toBe(1)
+    expect(cleanupCalls).toBe(1)
+  })
+
+  it('cleans retained successes only after their persisted sequenced or legacy cursor', async () => {
+    const databaseName = uniqueName('delivery_cleanup_cursors')
+    const consumerGroup = 'delivery-cleanup-cursors-group'
+    const topic = 'delivery-cleanup-cursors.topic'
+    const pulse = createPulse(databaseName, consumerGroup, {historyRetentionMs: 60_000})
+    await pulse.awaitConnection()
+    await pulse.subscribe(topic, async () => {}, {offsetReset: 'latest'})
+    const runtime = getRuntimeState(pulse)
+    await waitFor(() => runtime.discoveryLeases.has(topic))
+    runtime.running = false
+    runtime.wakeCoordinator()
+    await runtime.coordinatorPromise
+
+    const db = await rawDatabase(databaseName)
+    const now = new Date()
+    const cursorCreatedAt = new Date(now.getTime() - 1_000)
+    const cursorSequence = new Timestamp({t: 20, i: 2})
+    const [
+      lowerSequenceEventId,
+      lowerLegacyEventId,
+      cursorEventId,
+      higherSequenceEventId,
+      higherLegacyEventId,
+    ] = Array.from({length: 5}, () => uuidv7()).sort()
+    await db.collection('orionjs.pulse.subscriptions').updateOne(
+      {consumerGroup, topic},
+      {
+        $set: {
+          cursorCreatedAt,
+          cursorEventId,
+          cursorSequence,
+          cursorSequenceEventId: cursorEventId,
+          discoveryLockedUntil: new Date(Date.now() + 60_000),
+        },
+      },
+    )
+
+    const retainedUntil = new Date(Date.now() + 60_000)
+    const delivery = (
+      eventId: string,
+      options: {
+        status?: 'pending' | 'success' | 'error'
+        eventCreatedAt?: Date
+        eventSequence?: Timestamp
+        expiresAt?: Date
+      } = {},
+    ) => ({
+      _id: uuidv7(),
+      eventId,
+      consumerGroup,
+      topic,
+      eventCreatedAt: options.eventCreatedAt ?? cursorCreatedAt,
+      ...(options.eventSequence ? {eventSequence: options.eventSequence} : {}),
+      status: options.status ?? ('success' as const),
+      createdAt: now,
+      updatedAt: now,
+      ...(options.expiresAt ? {expiresAt: options.expiresAt} : {}),
+    })
+    const deletedEventIds = [uuidv7(), lowerSequenceEventId, uuidv7(), lowerLegacyEventId]
+    const keptEventIds = [
+      higherSequenceEventId,
+      uuidv7(),
+      higherLegacyEventId,
+      uuidv7(),
+      uuidv7(),
+      uuidv7(),
+      uuidv7(),
+    ]
+    await db.collection<any>('orionjs.pulse.deliveries').insertMany([
+      delivery(deletedEventIds[0], {
+        eventSequence: new Timestamp({t: 20, i: 1}),
+        expiresAt: retainedUntil,
+      }),
+      delivery(deletedEventIds[1], {eventSequence: cursorSequence, expiresAt: retainedUntil}),
+      delivery(keptEventIds[0], {eventSequence: cursorSequence, expiresAt: retainedUntil}),
+      delivery(keptEventIds[1], {
+        eventSequence: new Timestamp({t: 20, i: 3}),
+        expiresAt: retainedUntil,
+      }),
+      delivery(deletedEventIds[2], {
+        eventCreatedAt: new Date(cursorCreatedAt.getTime() - 1),
+        expiresAt: retainedUntil,
+      }),
+      delivery(deletedEventIds[3], {expiresAt: retainedUntil}),
+      delivery(keptEventIds[2], {expiresAt: retainedUntil}),
+      delivery(keptEventIds[3], {
+        eventCreatedAt: new Date(cursorCreatedAt.getTime() + 1),
+        expiresAt: retainedUntil,
+      }),
+      delivery(keptEventIds[4], {
+        eventCreatedAt: new Date(cursorCreatedAt.getTime() - 1),
+      }),
+      delivery(keptEventIds[5], {
+        status: 'pending',
+        eventCreatedAt: new Date(cursorCreatedAt.getTime() - 1),
+        expiresAt: retainedUntil,
+      }),
+      delivery(keptEventIds[6], {
+        status: 'error',
+        eventCreatedAt: new Date(cursorCreatedAt.getTime() - 1),
+        expiresAt: retainedUntil,
+      }),
+    ])
+
+    const originalHistoryFind = runtime.collections.history.find
+    const originalDeliveryFind = runtime.collections.deliveries.find
+    let cleanupFilter: Document | undefined
+    runtime.collections.history.find = () => {
+      throw new Error('Delivery cleanup must not query history.')
+    }
+    runtime.collections.deliveries.find = (...args: any[]) => {
+      cleanupFilter = args[0]
+      return originalDeliveryFind.apply(runtime.collections.deliveries, args)
+    }
+    try {
+      expect(await runtime.cleanupSuccessfulDeliveries([topic])).toBe(4)
+    } finally {
+      runtime.collections.history.find = originalHistoryFind
+      runtime.collections.deliveries.find = originalDeliveryFind
+    }
+    if (!cleanupFilter) throw new Error('Delivery cleanup did not issue its candidate query.')
+    const cleanupExplain = await db
+      .collection('orionjs.pulse.deliveries')
+      .find(cleanupFilter)
+      .limit(1_000)
+      .explain('executionStats')
+    const cleanupPlan = JSON.stringify(cleanupExplain.queryPlanner.winningPlan)
+    expect(cleanupPlan).toContain('pulse_deliveries_acquisition')
+    expect(cleanupPlan).toContain('pulse_deliveries_sequence_acquisition')
+    expect(cleanupPlan).not.toContain('COLLSCAN')
+
+    const remaining = await db
+      .collection('orionjs.pulse.deliveries')
+      .find({}, {projection: {eventId: 1}})
+      .toArray()
+    expect(remaining.map(item => item.eventId).sort()).toEqual(keptEventIds.sort())
+  })
+
+  it('batches cleanup without expiresAt only on the persisted discovery leader', async () => {
+    const databaseName = uniqueName('delivery_cleanup_leader')
+    const consumerGroup = 'delivery-cleanup-leader-group'
+    const topic = 'delivery-cleanup-leader.topic'
+    const replicas = [
+      createPulse(databaseName, consumerGroup),
+      createPulse(databaseName, consumerGroup),
+    ]
+    await Promise.all(replicas.map(replica => replica.awaitConnection()))
+    await Promise.all(
+      replicas.map(replica => replica.subscribe(topic, async () => {}, {offsetReset: 'latest'})),
+    )
+    const runtimes = replicas.map(getRuntimeState)
+    await waitFor(() => runtimes.filter(runtime => runtime.discoveryLeases.has(topic)).length === 1)
+    const leader = runtimes.find(runtime => runtime.discoveryLeases.has(topic))
+    const follower = runtimes.find(runtime => !runtime.discoveryLeases.has(topic))
+    if (!leader || !follower) throw new Error('Expected one discovery leader and one follower.')
+    for (const runtime of runtimes) {
+      runtime.running = false
+      runtime.wakeCoordinator()
+    }
+    await Promise.all(runtimes.map(runtime => runtime.coordinatorPromise))
+
+    const db = await rawDatabase(databaseName)
+    const cursorCreatedAt = new Date()
+    await db.collection('orionjs.pulse.subscriptions').updateOne(
+      {consumerGroup, topic},
+      {
+        $set: {
+          cursorCreatedAt,
+          cursorEventId: '',
+          discoveryLockedUntil: new Date(Date.now() + 60_000),
+        },
+      },
+    )
+    const createdAt = new Date(cursorCreatedAt.getTime() - 1)
+    await db.collection<any>('orionjs.pulse.deliveries').insertMany(
+      Array.from({length: 1_005}, () => ({
+        _id: uuidv7(),
+        eventId: uuidv7(),
+        consumerGroup,
+        topic,
+        eventCreatedAt: createdAt,
+        status: 'success',
+        createdAt,
+        updatedAt: createdAt,
+      })),
+    )
+
+    expect(await follower.cleanupSuccessfulDeliveries([topic])).toBe(0)
+    expect(await db.collection('orionjs.pulse.deliveries').countDocuments()).toBe(1_005)
+    expect(await leader.cleanupSuccessfulDeliveries([topic])).toBe(1_000)
+    expect(await db.collection('orionjs.pulse.deliveries').countDocuments()).toBe(5)
+    expect(await leader.cleanupSuccessfulDeliveries([topic])).toBe(5)
+    expect(await db.collection('orionjs.pulse.deliveries').countDocuments()).toBe(0)
   })
 
   it('keeps the real aggregate pipelines bounded at late cursors', async () => {

--- a/packages/pulse/src/Pulse.test.ts
+++ b/packages/pulse/src/Pulse.test.ts
@@ -150,6 +150,23 @@ describe('Pulse persistence', () => {
     expect(getMaxPoolSize(configuredPulse)).toBe(12)
   })
 
+  it('uses unordered delivery by default', async () => {
+    const databaseName = uniqueName('default_unordered')
+    const pulse = createPulse(databaseName, 'default-unordered-group')
+    const subscription = await pulse.subscribe('default-unordered.topic', async () => {})
+
+    expect(subscription.ordered).toBe(false)
+    expect(subscription.maxConcurrency).toBe(4)
+
+    const db = await rawDatabase(databaseName)
+    expect(
+      await db.collection('orionjs.pulse.subscriptions').findOne({
+        consumerGroup: 'default-unordered-group',
+        topic: 'default-unordered.topic',
+      }),
+    ).toMatchObject({ordered: false})
+  })
+
   it('rejects invalid MongoDB pool sizes before connecting', () => {
     for (const maxPoolSize of [0, -1, 1.5, Number.POSITIVE_INFINITY]) {
       expect(() =>
@@ -893,7 +910,7 @@ describe('Pulse delivery semantics', () => {
         callbacks++
         if (callbacks === 1) throw new Error('retry once')
       },
-      {retryDelayMs: 400, maxRetries: 1},
+      {ordered: true, retryDelayMs: 400, maxRetries: 1},
     )
 
     const subscriptions = getRuntimeState(pulse).collections.subscriptions

--- a/packages/pulse/src/Pulse.test.ts
+++ b/packages/pulse/src/Pulse.test.ts
@@ -156,6 +156,7 @@ describe('Pulse persistence', () => {
     const subscription = await pulse.subscribe('default-unordered.topic', async () => {})
 
     expect(subscription.ordered).toBe(false)
+    expect(subscription.configVersion).toBe(0)
     expect(subscription.maxConcurrency).toBe(4)
 
     const db = await rawDatabase(databaseName)
@@ -164,7 +165,73 @@ describe('Pulse persistence', () => {
         consumerGroup: 'default-unordered-group',
         topic: 'default-unordered.topic',
       }),
-    ).toMatchObject({ordered: false})
+    ).toMatchObject({ordered: false, configVersion: 0})
+  })
+
+  it('preserves legacy ordering when ordered is omitted', async () => {
+    const databaseName = uniqueName('legacy_ordering')
+    const consumerGroup = 'legacy-ordering-group'
+    const topic = 'legacy-ordering.topic'
+    const first = createPulse(databaseName, consumerGroup)
+    await first.subscribe(topic, async () => {}, {ordered: true})
+    await first.close()
+
+    const db = await rawDatabase(databaseName)
+    await db
+      .collection('orionjs.pulse.subscriptions')
+      .updateOne({consumerGroup, topic}, {$unset: {configVersion: ''}})
+
+    const replacement = createPulse(databaseName, consumerGroup)
+    const subscription = await replacement.subscribe(topic, async () => {})
+
+    expect(subscription.ordered).toBe(true)
+    expect(subscription.configVersion).toBe(0)
+  })
+
+  it('adopts the highest subscription configVersion without downgrading', async () => {
+    const databaseName = uniqueName('config_version')
+    const consumerGroup = 'config-version-group'
+    const topic = 'config-version.topic'
+    const first = createPulse(databaseName, consumerGroup)
+    const winner = createPulse(databaseName, consumerGroup)
+    const stale = createPulse(databaseName, consumerGroup)
+
+    await first.subscribe(topic, async () => {}, {ordered: true, configVersion: 1})
+    const updated = await winner.subscribe(topic, async () => {}, {
+      ordered: false,
+      configVersion: 2,
+    })
+    const staleResult = await stale.subscribe(topic, async () => {}, {
+      ordered: true,
+      configVersion: 1,
+    })
+
+    expect(updated).toMatchObject({ordered: false, configVersion: 2})
+    expect(staleResult).toMatchObject({ordered: false, configVersion: 2})
+
+    const runtime = getRuntimeState(first)
+    runtime.discoveryRefreshAt = 0
+    await runtime.refreshDiscoveryLeases()
+    expect(first.getSubscriptions()[0]).toMatchObject({ordered: false, configVersion: 2})
+
+    const db = await rawDatabase(databaseName)
+    expect(
+      await db.collection('orionjs.pulse.subscriptions').findOne({consumerGroup, topic}),
+    ).toMatchObject({ordered: false, configVersion: 2})
+  })
+
+  it('rejects different settings at the same configVersion', async () => {
+    const databaseName = uniqueName('config_version_conflict')
+    const consumerGroup = 'config-version-conflict-group'
+    const topic = 'config-version-conflict.topic'
+    const first = createPulse(databaseName, consumerGroup)
+    const conflicting = createPulse(databaseName, consumerGroup)
+
+    await first.subscribe(topic, async () => {}, {ordered: false, configVersion: 2})
+
+    await expect(
+      conflicting.subscribe(topic, async () => {}, {ordered: true, configVersion: 2}),
+    ).rejects.toThrow('Increase configVersion to change it')
   })
 
   it('rejects invalid MongoDB pool sizes before connecting', () => {
@@ -1417,6 +1484,8 @@ describe('Pulse disaster recovery and edge cases', () => {
       {maxConcurrency: 1.5},
       {maxConcurrency: 0},
       {ordered: 'yes' as any},
+      {configVersion: -1},
+      {configVersion: 1.5},
       {offsetReset: 'middle' as any},
       {delivery: 'maybe' as any},
       {retryDelayMs: Number.MAX_VALUE},

--- a/packages/pulse/src/Pulse.test.ts
+++ b/packages/pulse/src/Pulse.test.ts
@@ -48,6 +48,8 @@ function getRuntimeState(pulse: Pulse<any>) {
     activeExecutions: Set<Promise<void>>
     discoveryLeases: Map<string, unknown>
     discoveryRefreshAt: number
+    nextReapAt: number
+    nextReconciliationAt: number
     localSubscriptions: Map<string, {running: number}>
     running: boolean
     collections: {
@@ -57,6 +59,7 @@ function getRuntimeState(pulse: Pulse<any>) {
       history: any
     }
     wakeCoordinator(): void
+    coordinateOnce(): Promise<boolean>
     discoverEvents(scanEvents: boolean): Promise<{discovered: boolean; scanned: boolean}>
     refreshDiscoveryLeases(): Promise<void>
     findExecutionCandidates(capacity: number): Promise<unknown[]>
@@ -307,6 +310,11 @@ describe('Pulse persistence', () => {
           key: {status: 1, eventCreatedAt: 1, eventId: 1},
         },
         {
+          name: 'pulse_deliveries_reconciliation',
+          key: {consumerGroup: 1, topic: 1},
+          partialFilterExpression: {needsReconciliation: true},
+        },
+        {
           name: 'pulse_deliveries_expires_at_ttl',
           key: {expiresAt: 1},
           expireAfterSeconds: 0,
@@ -333,6 +341,11 @@ describe('Pulse persistence', () => {
           key: {consumerGroup: 1, topic: 1, status: 1, nextAttemptAt: 1, createdAt: 1},
         },
         {
+          name: 'pulse_history_reconciliation',
+          key: {consumerGroup: 1, topic: 1},
+          partialFilterExpression: {needsReconciliation: true},
+        },
+        {
           name: 'pulse_history_expires_at_ttl',
           key: {expiresAt: 1},
           expireAfterSeconds: 0,
@@ -350,6 +363,11 @@ describe('Pulse persistence', () => {
         )
         expect(index?.expireAfterSeconds).toBe(
           'expireAfterSeconds' in expectedIndex ? expectedIndex.expireAfterSeconds : undefined,
+        )
+        expect(index?.partialFilterExpression).toEqual(
+          'partialFilterExpression' in expectedIndex
+            ? expectedIndex.partialFilterExpression
+            : undefined,
         )
       }
     }
@@ -423,6 +441,29 @@ describe('Pulse persistence', () => {
         nextAttemptAt: now,
       })),
     )
+    await db.collection<any>('orionjs.pulse.deliveries').insertOne({
+      _id: uuidv7(),
+      eventId: uuidv7(),
+      consumerGroup,
+      topic,
+      eventCreatedAt: now,
+      status: 'pending',
+      createdAt: now,
+      updatedAt: now,
+      needsReconciliation: true,
+    })
+    await db.collection<any>('orionjs.pulse.history').insertOne({
+      _id: uuidv7(),
+      deliveryId: uuidv7(),
+      eventId: uuidv7(),
+      consumerGroup,
+      topic,
+      attempt: 1,
+      status: 'success',
+      createdAt: now,
+      nextAttemptAt: now,
+      needsReconciliation: true,
+    })
 
     const legacyExplain = await db
       .collection('orionjs.pulse.events')
@@ -466,6 +507,16 @@ describe('Pulse persistence', () => {
       .sort({lockedUntil: 1})
       .limit(25)
       .explain('executionStats')
+    const deliveryReconciliationExplain = await db
+      .collection('orionjs.pulse.deliveries')
+      .find({consumerGroup, topic: {$in: [topic]}, needsReconciliation: true})
+      .limit(25)
+      .explain('executionStats')
+    const historyReconciliationExplain = await db
+      .collection('orionjs.pulse.history')
+      .find({consumerGroup, topic: {$in: [topic]}, needsReconciliation: true})
+      .limit(25)
+      .explain('executionStats')
 
     const assertions: Array<[unknown, string]> = [
       [legacyExplain, 'pulse_events_legacy_topic_created_id'],
@@ -473,6 +524,8 @@ describe('Pulse persistence', () => {
       [dashboardPendingExplain, 'pulse_deliveries_dashboard_pending'],
       [historyExplain, 'pulse_history_pending_acquisition'],
       [deadLockExplain, 'pulse_history_group_dead_locks'],
+      [deliveryReconciliationExplain, 'pulse_deliveries_reconciliation'],
+      [historyReconciliationExplain, 'pulse_history_reconciliation'],
     ]
     for (const [explain, expectedIndex] of assertions) {
       const winningPlan = JSON.stringify((explain as any).queryPlanner.winningPlan)
@@ -480,6 +533,40 @@ describe('Pulse persistence', () => {
       expect(winningPlan).not.toContain('COLLSCAN')
       expect(winningPlan).not.toContain('"stage":"SORT"')
     }
+  })
+
+  it('keeps maintenance queries out of repeated coordinator work iterations', async () => {
+    const databaseName = uniqueName('maintenance_schedule')
+    const topic = 'maintenance-schedule.topic'
+    const pulse = createPulse(databaseName, 'maintenance-schedule-group')
+    await pulse.awaitConnection()
+    await pulse.subscribe(topic, async () => {}, {offsetReset: 'latest'})
+    const runtime = getRuntimeState(pulse)
+    await waitFor(() => runtime.discoveryLeases.has(topic))
+    runtime.running = false
+    runtime.wakeCoordinator()
+    await runtime.coordinatorPromise
+
+    let reapCalls = 0
+    let reconciliationCalls = 0
+    runtime.reapExpiredAttempts = async () => {
+      reapCalls++
+      runtime.nextReapAt = Date.now() + 60_000
+      return 0
+    }
+    runtime.reconcileDeliveries = async () => {
+      reconciliationCalls++
+      runtime.nextReconciliationAt = Date.now() + 60_000
+      return 0
+    }
+    runtime.nextReapAt = 0
+    runtime.nextReconciliationAt = 0
+
+    await runtime.coordinateOnce()
+    await Promise.all(Array.from({length: 10}, () => runtime.coordinateOnce()))
+
+    expect(reapCalls).toBe(1)
+    expect(reconciliationCalls).toBe(1)
   })
 
   it('keeps the real aggregate pipelines bounded at late cursors', async () => {
@@ -1354,6 +1441,7 @@ describe('Pulse delivery semantics', () => {
       startedAt: createdAt,
       endedAt: createdAt,
       durationMs: 0,
+      needsReconciliation: true,
     })
 
     let callbackCount = 0
@@ -1412,6 +1500,7 @@ describe('Pulse disaster recovery and edge cases', () => {
       status: 'pending',
       createdAt: now,
       updatedAt: now,
+      needsReconciliation: true,
     }))
     await db
       .collection('orionjs.pulse.deliveries')
@@ -1922,6 +2011,7 @@ describe('Pulse disaster recovery and edge cases', () => {
       createdAt: endedAt,
       updatedAt: endedAt,
       endedAt,
+      needsReconciliation: true,
     })
     await db.collection('orionjs.pulse.history').insertOne({
       _id: uuidv7(),
@@ -1976,6 +2066,7 @@ describe('Pulse disaster recovery and edge cases', () => {
       status: 'pending',
       createdAt,
       updatedAt: createdAt,
+      needsReconciliation: true,
     })
 
     let calls = 0
@@ -1997,9 +2088,9 @@ describe('Pulse disaster recovery and edge cases', () => {
     expect(await db.collection('orionjs.pulse.history').countDocuments({deliveryId})).toBe(1)
   })
 
-  it('rotates reconciliation past healthy heads in at least twenty-five topics', async () => {
-    const databaseName = uniqueName('reconciliation_head_rotation')
-    const consumerGroup = 'reconciliation-head-rotation-group'
+  it('drains marked reconciliation work in bounded batches', async () => {
+    const databaseName = uniqueName('reconciliation_batches')
+    const consumerGroup = 'reconciliation-batches-group'
     const pulse = createPulse(databaseName, consumerGroup)
     await pulse.awaitConnection()
     const runtime = getRuntimeState(pulse)
@@ -2007,51 +2098,32 @@ describe('Pulse disaster recovery and edge cases', () => {
     runtime.wakeCoordinator()
     await runtime.coordinatorPromise
     const db = await rawDatabase(databaseName)
-    const topics = Array.from({length: 25}, (_, index) => `reconciliation-head.${index}`)
+    const topics = Array.from({length: 25}, (_, index) => `reconciliation-batch.${index}`)
     const now = new Date()
-    const deliveries = topics.map((topic, index) => ({
+    const deliveries = Array.from({length: 26}, (_, index) => ({
       _id: uuidv7(),
       eventId: uuidv7(),
       consumerGroup,
-      topic,
+      topic: topics[index % topics.length],
       eventCreatedAt: new Date(now.getTime() + index),
       status: 'pending',
       createdAt: now,
       updatedAt: now,
+      needsReconciliation: true,
     }))
-    const torn = {
-      _id: uuidv7(),
-      eventId: uuidv7(),
-      consumerGroup,
-      topic: topics[0],
-      eventCreatedAt: new Date(now.getTime() + 10_000),
-      status: 'pending',
-      createdAt: now,
-      updatedAt: now,
-    }
-    await db.collection<any>('orionjs.pulse.deliveries').insertMany([...deliveries, torn])
-    await db.collection<any>('orionjs.pulse.history').insertMany(
-      deliveries.map(delivery => ({
-        _id: uuidv7(),
-        deliveryId: delivery._id,
-        eventId: delivery.eventId,
-        consumerGroup,
-        topic: delivery.topic,
-        attempt: 1,
-        status: 'pending',
-        createdAt: now,
-        nextAttemptAt: new Date(now.getTime() + 60_000),
-      })),
-    )
+    await db.collection<any>('orionjs.pulse.deliveries').insertMany(deliveries)
 
-    expect(await runtime.reconcileDeliveries(topics)).toBe(0)
-    expect(
-      await db.collection('orionjs.pulse.history').countDocuments({deliveryId: torn._id}),
-    ).toBe(0)
+    expect(await runtime.reconcileDeliveries(topics)).toBe(25)
+    expect(runtime.nextReconciliationAt).toBe(0)
+    expect(await db.collection('orionjs.pulse.history').countDocuments({attempt: 1})).toBe(25)
     expect(await runtime.reconcileDeliveries(topics)).toBe(1)
+    expect(runtime.nextReconciliationAt).toBeGreaterThan(Date.now())
+    expect(await db.collection('orionjs.pulse.history').countDocuments({attempt: 1})).toBe(26)
     expect(
-      await db.collection('orionjs.pulse.history').countDocuments({deliveryId: torn._id}),
-    ).toBe(1)
+      await db.collection('orionjs.pulse.deliveries').countDocuments({
+        needsReconciliation: true,
+      }),
+    ).toBe(0)
   })
 
   it('creates exactly one retry when replicas reconcile the same partial error', async () => {
@@ -2100,6 +2172,7 @@ describe('Pulse disaster recovery and edge cases', () => {
         name: 'Error',
         message: 'crashed before retry creation',
       },
+      needsReconciliation: true,
     })
 
     const attempts: number[] = []
@@ -2432,6 +2505,7 @@ describe('Pulse disaster recovery and edge cases', () => {
           status: 'pending',
           createdAt,
           updatedAt: createdAt,
+          needsReconciliation: true,
         })
 
         if (category === 'success-before-delivery') {

--- a/packages/pulse/src/Pulse.ts
+++ b/packages/pulse/src/Pulse.ts
@@ -43,6 +43,8 @@ const DISCOVERY_TOPIC_BATCH_SIZE = 50
 const RECONCILIATION_BATCH_SIZE = 25
 const RECONCILIATION_INTERVAL_MS = 30_000
 const MAX_REAPER_IDLE_INTERVAL_MS = 10_000
+const DELIVERY_CLEANUP_BATCH_SIZE = 1_000
+const DELIVERY_CLEANUP_INTERVAL_MS = 60_000
 const MAX_DATE_MS = 8_640_000_000_000_000
 
 interface ResolvedConnectOptions {
@@ -399,6 +401,7 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
   private localSubscriptionRevision = 0
   private discoveryTopicOffset = 0
   private workTopicOffset = Math.floor(Math.random() * 1_000_000_000)
+  private deliveryCleanupTopicOffset = 0
   private db?: Db
   private collections?: PulseCollections
   private coordinatorPromise?: Promise<void>
@@ -407,6 +410,7 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
   private nextDiscoveryAt = 0
   private nextReapAt = 0
   private nextReconciliationAt = 0
+  private nextDeliveryCleanupAt = Date.now() + DELIVERY_CLEANUP_INTERVAL_MS
   private running = true
   private closePromise?: Promise<void>
 
@@ -595,11 +599,15 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
     )
     let reaped = 0
     let reconciled = 0
+    let cleaned = 0
     if (leaderTopics.length > 0) {
       const now = Date.now()
       if (now >= this.nextReapAt) reaped = await this.reapExpiredAttempts(leaderTopics)
       if (now >= this.nextReconciliationAt) {
         reconciled = await this.reconcileDeliveries(leaderTopics)
+      }
+      if (now >= this.nextDeliveryCleanupAt) {
+        cleaned = await this.cleanupSuccessfulDeliveries(leaderTopics)
       }
     }
 
@@ -611,7 +619,7 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
       this.startExecution(execution)
       dispatched = true
     }
-    return discovery.discovered || reaped > 0 || reconciled > 0 || dispatched
+    return discovery.discovered || reaped > 0 || reconciled > 0 || cleaned > 0 || dispatched
   }
 
   private async discoverEvents(scanEvents: boolean): Promise<DiscoveryResult> {
@@ -1644,6 +1652,80 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
     this.nextReconciliationAt =
       reconciled === RECONCILIATION_BATCH_SIZE ? 0 : Date.now() + RECONCILIATION_INTERVAL_MS
     return reconciled
+  }
+
+  private async cleanupSuccessfulDeliveries(topics: string[]) {
+    this.nextDeliveryCleanupAt = Date.now() + DELIVERY_CLEANUP_INTERVAL_MS
+    if (topics.length === 0) return 0
+
+    const selectedTopics = circularBatch(
+      topics,
+      this.deliveryCleanupTopicOffset,
+      DISCOVERY_TOPIC_BATCH_SIZE,
+    )
+    this.deliveryCleanupTopicOffset =
+      (this.deliveryCleanupTopicOffset + selectedTopics.length) % topics.length
+
+    const now = new Date()
+    const collections = this.getCollections()
+    const subscriptions = await collections.subscriptions
+      .find({
+        consumerGroup: this.options.consumerGroup,
+        topic: {$in: selectedTopics},
+        discoveryLockOwner: this.coordinatorId,
+        discoveryLockedUntil: {$gt: now},
+      })
+      .toArray()
+    const cursorBranches: Document[] = []
+    for (const subscription of subscriptions) {
+      if (subscription.cursorSequence) {
+        cursorBranches.push({
+          topic: subscription.topic,
+          eventSequence: {$lt: subscription.cursorSequence},
+        })
+        if (subscription.cursorSequenceEventId !== undefined) {
+          cursorBranches.push({
+            topic: subscription.topic,
+            eventSequence: subscription.cursorSequence,
+            eventId: {$lte: subscription.cursorSequenceEventId},
+          })
+        }
+      }
+      if (subscription.cursorCreatedAt) {
+        cursorBranches.push({
+          topic: subscription.topic,
+          eventSequence: {$exists: false},
+          eventCreatedAt: {$lt: subscription.cursorCreatedAt},
+        })
+        if (subscription.cursorEventId !== undefined) {
+          cursorBranches.push({
+            topic: subscription.topic,
+            eventSequence: {$exists: false},
+            eventCreatedAt: subscription.cursorCreatedAt,
+            eventId: {$lte: subscription.cursorEventId},
+          })
+        }
+      }
+    }
+    if (cursorBranches.length === 0) return 0
+
+    const eligible = {
+      consumerGroup: this.options.consumerGroup,
+      status: 'success' as const,
+      ...(this.options.historyRetentionMs === null ? {} : {expiresAt: {$exists: true}}),
+      $or: cursorBranches,
+    }
+    const candidates = await collections.deliveries
+      .find(eligible, {projection: {_id: 1}})
+      .limit(DELIVERY_CLEANUP_BATCH_SIZE)
+      .toArray()
+    if (candidates.length === 0) return 0
+
+    const result = await collections.deliveries.deleteMany({
+      ...eligible,
+      _id: {$in: candidates.map(delivery => delivery._id)},
+    })
+    return result.deletedCount
   }
 
   /*

--- a/packages/pulse/src/Pulse.ts
+++ b/packages/pulse/src/Pulse.ts
@@ -225,7 +225,7 @@ function resolveSubscribeOptions(
     throw new PulseConfigurationError('subscribe options must be an object.')
   }
   const resolved: ResolvedSubscribeOptions = {
-    ordered: options.ordered ?? true,
+    ordered: options.ordered ?? false,
     offsetReset: options.offsetReset ?? 'latest',
     delivery: options.delivery ?? 'at-least-once',
     maxRetries: options.maxRetries ?? 3,

--- a/packages/pulse/src/Pulse.ts
+++ b/packages/pulse/src/Pulse.ts
@@ -225,6 +225,7 @@ function resolveSubscribeOptions(
     throw new PulseConfigurationError('subscribe options must be an object.')
   }
   const resolved: ResolvedSubscribeOptions = {
+    configVersion: options.configVersion ?? 0,
     ordered: options.ordered ?? false,
     offsetReset: options.offsetReset ?? 'latest',
     delivery: options.delivery ?? 'at-least-once',
@@ -235,6 +236,7 @@ function resolveSubscribeOptions(
   }
 
   assertBoolean(resolved.ordered, 'ordered')
+  assertNonNegativeInteger(resolved.configVersion, 'configVersion')
   assertOneOf(resolved.offsetReset, ['latest', 'earliest'], 'offsetReset')
   assertOneOf(resolved.delivery, ['at-least-once', 'at-most-once'], 'delivery')
   assertNonNegativeInteger(resolved.maxRetries, 'maxRetries')
@@ -313,6 +315,7 @@ function serializeError(error: unknown, code = 'handler_error'): PulseHistoryErr
 
 function subscriptionConfig(document: SubscriptionDocument) {
   return {
+    configVersion: document.configVersion ?? 0,
     ordered: document.ordered,
     offsetReset: document.offsetReset,
     delivery: document.delivery,
@@ -324,6 +327,7 @@ function subscriptionConfig(document: SubscriptionDocument) {
 
 function configsMatch(document: SubscriptionDocument, options: ResolvedSubscribeOptions) {
   const expected = {
+    configVersion: options.configVersion,
     ordered: options.ordered,
     offsetReset: options.offsetReset,
     delivery: options.delivery,
@@ -332,6 +336,33 @@ function configsMatch(document: SubscriptionDocument, options: ResolvedSubscribe
     retryBackoffMultiplier: options.retryBackoffMultiplier,
   }
   return JSON.stringify(subscriptionConfig(document)) === JSON.stringify(expected)
+}
+
+function persistedConfig(options: ResolvedSubscribeOptions) {
+  return {
+    configVersion: options.configVersion,
+    ordered: options.ordered,
+    offsetReset: options.offsetReset,
+    delivery: options.delivery,
+    maxRetries: options.maxRetries,
+    retryDelayMs: options.retryDelayMs,
+    retryBackoffMultiplier: options.retryBackoffMultiplier,
+  }
+}
+
+function optionsFromDocument(
+  document: SubscriptionDocument,
+  configuredMaxConcurrency: number,
+): ResolvedSubscribeOptions {
+  return {
+    ...subscriptionConfig(document),
+    maxConcurrency: document.ordered ? 1 : configuredMaxConcurrency,
+  }
+}
+
+function configVersionFilter(configVersion: number) {
+  if (configVersion !== 0) return {configVersion}
+  return {$or: [{configVersion: 0}, {configVersion: {$exists: false}}]}
 }
 
 function circularBatch<T>(items: T[], offset: number, limit: number) {
@@ -456,13 +487,15 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
       )
     }
 
-    const options = resolveSubscribeOptions(userOptions, this.options.workerCount)
+    const configuredMaxConcurrency = userOptions.maxConcurrency ?? this.options.workerCount
+    const requestedOptions = resolveSubscribeOptions(userOptions, this.options.workerCount)
     this.subscribingTopics.add(topic)
     try {
-      const document = await this.getOrCreateSubscription(topic, options)
+      const document = await this.getOrCreateSubscription(topic, requestedOptions, userOptions)
       const local: LocalSubscription = {
         document,
-        options,
+        options: optionsFromDocument(document, configuredMaxConcurrency),
+        configuredMaxConcurrency,
         handler: handler as PulseEventHandler<string, unknown>,
         running: 0,
         unsubscribed: false,
@@ -683,13 +716,16 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
       const local = this.localSubscriptions.get(topic)
       const expectedToken = batchLeaseTokens.get(topic)
       if (!local || local.unsubscribed || !expectedToken || invalidTopics.has(topic)) continue
-      local.document = await this.advanceDiscoveryCursor(
-        local.document,
-        {
-          cursorCreatedAt: event.createdAt,
-          cursorEventId: event._id,
-        },
-        expectedToken,
+      this.updateLocalSubscription(
+        local,
+        await this.advanceDiscoveryCursor(
+          local.document,
+          {
+            cursorCreatedAt: event.createdAt,
+            cursorEventId: event._id,
+          },
+          expectedToken,
+        ),
       )
     }
     for (const [topic, event] of latestSequenced) {
@@ -697,13 +733,16 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
       const local = this.localSubscriptions.get(topic)
       const expectedToken = batchLeaseTokens.get(topic)
       if (!local || local.unsubscribed || !expectedToken || invalidTopics.has(topic)) continue
-      local.document = await this.advanceDiscoveryCursor(
-        local.document,
-        {
-          cursorSequence: event.sequence,
-          cursorSequenceEventId: event._id,
-        },
-        expectedToken,
+      this.updateLocalSubscription(
+        local,
+        await this.advanceDiscoveryCursor(
+          local.document,
+          {
+            cursorSequence: event.sequence,
+            cursorSequenceEventId: event._id,
+          },
+          expectedToken,
+        ),
       )
     }
 
@@ -1599,7 +1638,7 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
         this.discoveryLeases.delete(local.document.topic)
         continue
       }
-      local.document = document
+      this.updateLocalSubscription(local, document)
 
       let lease = this.discoveryLeases.get(document.topic)
       const observedToken = document.discoveryLockToken
@@ -1692,7 +1731,7 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
     for (const document of documents) {
       const local = this.localSubscriptions.get(document.topic)
       if (!local || local.unsubscribed) continue
-      local.document = document
+      this.updateLocalSubscription(local, document)
       if (
         document.discoveryLockOwner === this.coordinatorId &&
         typeof document.discoveryLockToken === 'string' &&
@@ -1851,23 +1890,22 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
 
   private async getOrCreateSubscription(
     topic: string,
-    options: ResolvedSubscribeOptions,
+    requestedOptions: ResolvedSubscribeOptions,
+    userOptions: PulseSubscribeOptions,
   ): Promise<SubscriptionDocument> {
-    let document = await this.getCollections().subscriptions.findOne({
-      consumerGroup: this.options.consumerGroup,
-      topic,
-    })
+    const subscriptions = this.getCollections().subscriptions
+    let document = await subscriptions.findOne({consumerGroup: this.options.consumerGroup, topic})
     if (!document) {
       const now = new Date()
       const latest =
-        options.offsetReset === 'latest'
+        requestedOptions.offsetReset === 'latest'
           ? await this.getCollections().events.findOne(
               {topic, sequence: {$exists: false}},
               {sort: {createdAt: -1, _id: -1}},
             )
           : undefined
       const latestSequenced =
-        options.offsetReset === 'latest'
+        requestedOptions.offsetReset === 'latest'
           ? await this.getCollections().events.findOne(
               {topic, sequence: {$exists: true}},
               {sort: {sequence: -1, _id: -1}},
@@ -1877,15 +1915,10 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
         _id: uuidv7(),
         consumerGroup: this.options.consumerGroup,
         topic,
-        ordered: options.ordered,
-        offsetReset: options.offsetReset,
-        delivery: options.delivery,
-        maxRetries: options.maxRetries,
-        retryDelayMs: options.retryDelayMs,
-        retryBackoffMultiplier: options.retryBackoffMultiplier,
+        ...persistedConfig(requestedOptions),
         createdAt: now,
         updatedAt: now,
-        ...(options.offsetReset === 'latest'
+        ...(requestedOptions.offsetReset === 'latest'
           ? {
               cursorCreatedAt: latest?.createdAt ?? now,
               cursorEventId: latest?._id ?? '',
@@ -1899,11 +1932,11 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
           : {}),
       }
       try {
-        await this.getCollections().subscriptions.insertOne(candidate)
+        await subscriptions.insertOne(candidate)
         document = candidate
       } catch (error) {
         if (!isDuplicateKeyError(error)) throw error
-        document = await this.getCollections().subscriptions.findOne({
+        document = await subscriptions.findOne({
           consumerGroup: this.options.consumerGroup,
           topic,
         })
@@ -1914,13 +1947,44 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
         `Failed to create Pulse subscription for ${this.options.consumerGroup}/${topic}.`,
       )
     }
-    if (!configsMatch(document, options)) {
-      throw new PulseConfigurationError(
-        `Subscription configuration for ${this.options.consumerGroup}/${topic} does not match ` +
-          `the persisted configuration. Existing=${JSON.stringify(subscriptionConfig(document))}.`,
+
+    while (true) {
+      const existingVersion = document.configVersion ?? 0
+      if (requestedOptions.configVersion < existingVersion) return document
+
+      const desiredOptions = {
+        ...requestedOptions,
+        ordered: userOptions.ordered ?? document.ordered,
+      }
+      if (requestedOptions.configVersion === existingVersion) {
+        if (configsMatch(document, desiredOptions)) return document
+        throw new PulseConfigurationError(
+          `Subscription configuration for ${this.options.consumerGroup}/${topic} does not match ` +
+            `the persisted configuration at configVersion ${existingVersion}. Increase ` +
+            `configVersion to change it. Existing=${JSON.stringify(subscriptionConfig(document))}, ` +
+            `requested=${JSON.stringify(persistedConfig(desiredOptions))}.`,
+        )
+      }
+
+      const updated = await subscriptions.findOneAndUpdate(
+        {_id: document._id, ...configVersionFilter(existingVersion)},
+        {$set: {...persistedConfig(desiredOptions), updatedAt: new Date()}},
+        {returnDocument: 'after'},
       )
+      if (updated) return updated
+
+      document = await subscriptions.findOne({_id: document._id})
+      if (!document) {
+        throw new Error(
+          `Pulse subscription disappeared for ${this.options.consumerGroup}/${topic}.`,
+        )
+      }
     }
-    return document
+  }
+
+  private updateLocalSubscription(local: LocalSubscription, document: SubscriptionDocument) {
+    local.document = document
+    local.options = optionsFromDocument(document, local.configuredMaxConcurrency)
   }
 
   private toSubscriptionInfo(local: LocalSubscription): PulseSubscriptionInfo {
@@ -1928,6 +1992,7 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
       id: local.document._id,
       topic: local.document.topic,
       consumerGroup: local.document.consumerGroup,
+      configVersion: local.options.configVersion,
       ordered: local.options.ordered,
       offsetReset: local.options.offsetReset,
       delivery: local.options.delivery,

--- a/packages/pulse/src/Pulse.ts
+++ b/packages/pulse/src/Pulse.ts
@@ -41,6 +41,8 @@ const DEFAULT_DISCOVERY_LOCK_TIMEOUT_MS = 10_000
 const DISCOVERY_BATCH_SIZE = 100
 const DISCOVERY_TOPIC_BATCH_SIZE = 50
 const RECONCILIATION_BATCH_SIZE = 25
+const RECONCILIATION_INTERVAL_MS = 30_000
+const MAX_REAPER_IDLE_INTERVAL_MS = 10_000
 const MAX_DATE_MS = 8_640_000_000_000_000
 
 interface ResolvedConnectOptions {
@@ -397,14 +399,14 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
   private localSubscriptionRevision = 0
   private discoveryTopicOffset = 0
   private workTopicOffset = Math.floor(Math.random() * 1_000_000_000)
-  private recoveryTopicOffset = Math.floor(Math.random() * 1_000_000_000)
-  private readonly recoveryCursors = new Map<string, {eventCreatedAt: Date; eventId: string}>()
   private db?: Db
   private collections?: PulseCollections
   private coordinatorPromise?: Promise<void>
   private discoveryRequestRevision = 0
   private handledDiscoveryRequestRevision = 0
   private nextDiscoveryAt = 0
+  private nextReapAt = 0
+  private nextReconciliationAt = 0
   private running = true
   private closePromise?: Promise<void>
 
@@ -594,8 +596,11 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
     let reaped = 0
     let reconciled = 0
     if (leaderTopics.length > 0) {
-      reaped = await this.reapExpiredAttempts(leaderTopics)
-      reconciled = await this.reconcileDeliveries(leaderTopics)
+      const now = Date.now()
+      if (now >= this.nextReapAt) reaped = await this.reapExpiredAttempts(leaderTopics)
+      if (now >= this.nextReconciliationAt) {
+        reconciled = await this.reconcileDeliveries(leaderTopics)
+      }
     }
 
     let dispatched = false
@@ -764,6 +769,7 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
         status: 'pending' as const,
         createdAt,
         updatedAt: createdAt,
+        needsReconciliation: true,
       } satisfies DeliveryDocument
     })
     try {
@@ -792,33 +798,55 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
       })
       .toArray()
     if (deliveries.length === 0) return
+    const deliveryIdsWithHistory = new Set(
+      await collections.history.distinct('deliveryId', {
+        deliveryId: {$in: deliveries.map(delivery => delivery._id)},
+      }),
+    )
+    const uninitializedDeliveries = deliveries.filter(
+      delivery => !deliveryIdsWithHistory.has(delivery._id),
+    )
+    if (uninitializedDeliveries.length === 0) return
+    const historyOperations = uninitializedDeliveries.map<AnyBulkWriteOperation<HistoryDocument>>(
+      delivery => {
+        const attempt: HistoryDocument = {
+          _id: uuidv7(),
+          deliveryId: delivery._id,
+          eventId: delivery.eventId,
+          consumerGroup: delivery.consumerGroup,
+          topic: delivery.topic,
+          attempt: 1,
+          status: 'pending',
+          createdAt: new Date(),
+          nextAttemptAt: delivery.createdAt,
+        }
+        return {
+          updateOne: {
+            filter: {deliveryId: delivery._id, attempt: 1},
+            update: {$setOnInsert: attempt},
+            upsert: true,
+          },
+        }
+      },
+    )
+    let initializedDeliveryIds: string[] = []
     try {
-      await collections.history.bulkWrite(
-        deliveries.map<AnyBulkWriteOperation<HistoryDocument>>(delivery => {
-          const attempt: HistoryDocument = {
-            _id: uuidv7(),
-            deliveryId: delivery._id,
-            eventId: delivery.eventId,
-            consumerGroup: delivery.consumerGroup,
-            topic: delivery.topic,
-            attempt: 1,
-            status: 'pending',
-            createdAt: new Date(),
-            nextAttemptAt: delivery.createdAt,
-          }
-          return {
-            updateOne: {
-              filter: {deliveryId: delivery._id, attempt: 1},
-              update: {$setOnInsert: attempt},
-              upsert: true,
-            },
-          }
-        }),
-        {ordered: false},
+      const result = await collections.history.bulkWrite(historyOperations, {ordered: false})
+      initializedDeliveryIds = Object.keys(result.upsertedIds).map(
+        index => uninitializedDeliveries[Number(index)]._id,
       )
     } catch (error) {
       if (!isOnlyDuplicateKeyErrors(error)) throw error
     }
+    if (initializedDeliveryIds.length === 0) return
+    await collections.deliveries.updateMany(
+      {
+        _id: {$in: initializedDeliveryIds},
+        status: 'pending',
+        needsReconciliation: true,
+      },
+      {$unset: {needsReconciliation: ''}},
+    )
   }
 
   private async claimExecutions(capacity: number): Promise<ClaimedExecution[]> {
@@ -1261,6 +1289,7 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
           status: 'success',
           endedAt,
           durationMs: attempt.startedAt ? endedAt.getTime() - attempt.startedAt.getTime() : 0,
+          needsReconciliation: true,
         },
         $unset: {expiresAt: ''},
       },
@@ -1279,6 +1308,7 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
           error,
           endedAt,
           durationMs: attempt.startedAt ? endedAt.getTime() - attempt.startedAt.getTime() : 0,
+          needsReconciliation: true,
         },
         $unset: {expiresAt: ''},
       },
@@ -1319,6 +1349,10 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
       {_id: delivery._id, status: 'pending'},
       {$set: {updatedAt: new Date()}},
     )
+    await this.getCollections().history.updateOne(
+      {_id: history._id, status: 'error', needsReconciliation: true},
+      {$unset: {needsReconciliation: ''}},
+    )
     this.wakeCoordinator()
   }
 
@@ -1332,6 +1366,7 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
           finalAttempt: history.attempt,
           updatedAt: endedAt,
           endedAt,
+          needsReconciliation: true,
         },
         $unset: {error: '', expiresAt: ''},
       },
@@ -1352,6 +1387,7 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
           error: history.error,
           updatedAt: endedAt,
           endedAt,
+          needsReconciliation: true,
         },
         $unset: {expiresAt: ''},
       },
@@ -1366,17 +1402,29 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
       delivery.endedAt ?? delivery.updatedAt,
       this.options.historyRetentionMs,
     )
-    if (!expiresAt) return
+    if (!expiresAt) {
+      await Promise.all([
+        this.getCollections().history.updateMany(
+          {deliveryId: delivery._id, needsReconciliation: true},
+          {$unset: {needsReconciliation: ''}},
+        ),
+        this.getCollections().deliveries.updateOne(
+          {_id: delivery._id, status: delivery.status, needsReconciliation: true},
+          {$unset: {needsReconciliation: ''}},
+        ),
+      ])
+      return
+    }
 
     // Histories become expirable before their terminal delivery. If the process dies
     // between these writes, the delivery remains as a durable repair marker.
     await this.getCollections().history.updateMany(
       {deliveryId: delivery._id, status: {$in: ['success', 'error']}},
-      {$set: {expiresAt}},
+      {$set: {expiresAt}, $unset: {needsReconciliation: ''}},
     )
     await this.getCollections().deliveries.updateOne(
-      {_id: delivery._id, status: delivery.status, expiresAt: {$exists: false}},
-      {$set: {expiresAt}},
+      {_id: delivery._id, status: delivery.status},
+      {$set: {expiresAt}, $unset: {needsReconciliation: ''}},
     )
   }
 
@@ -1410,162 +1458,199 @@ export class Pulse<TEvents extends PulseEventMap = Record<string, unknown>> {
 
   private async reapExpiredAttempts(topics: string[]) {
     if (topics.length === 0) return 0
-    let reaped = 0
-
-    for (let inspected = 0; inspected < RECONCILIATION_BATCH_SIZE; inspected++) {
-      const now = new Date()
-      const candidate = await this.getCollections().history.findOne(
-        {
-          consumerGroup: this.options.consumerGroup,
-          topic: {$in: topics},
-          status: 'pending',
-          lockedUntil: {$lte: now},
-          lockToken: {$exists: true},
-        },
-        {sort: {lockedUntil: 1}},
+    const historyCollection = this.getCollections().history
+    const now = new Date()
+    const candidates = await historyCollection
+      .find({
+        consumerGroup: this.options.consumerGroup,
+        topic: {$in: topics},
+        status: 'pending',
+        lockedUntil: {$lte: now},
+        lockToken: {$exists: true},
+      })
+      .sort({lockedUntil: 1})
+      .limit(RECONCILIATION_BATCH_SIZE)
+      .toArray()
+    const reapedHistories = (
+      await Promise.all(
+        candidates.map(async candidate => {
+          const endedAt = new Date()
+          return await historyCollection.findOneAndUpdate(
+            {
+              _id: candidate._id,
+              status: 'pending',
+              lockToken: candidate.lockToken,
+              lockedUntil: {$lte: endedAt},
+            },
+            {
+              $set: {
+                status: 'error',
+                error: serializeError(
+                  new Error('The worker lock expired before the attempt completed.'),
+                  'worker_lost',
+                ),
+                endedAt,
+                durationMs: candidate.startedAt
+                  ? endedAt.getTime() - candidate.startedAt.getTime()
+                  : 0,
+                needsReconciliation: true,
+              },
+              $unset: {expiresAt: ''},
+            },
+            {returnDocument: 'after'},
+          )
+        }),
       )
-      if (!candidate) break
+    ).filter((history): history is HistoryDocument => Boolean(history))
 
-      const endedAt = new Date()
-      const history = await this.getCollections().history.findOneAndUpdate(
-        {
-          _id: candidate._id,
-          status: 'pending',
-          lockToken: candidate.lockToken,
-          lockedUntil: {$lte: endedAt},
-        },
-        {
-          $set: {
-            status: 'error',
-            error: serializeError(
-              new Error('The worker lock expired before the attempt completed.'),
-              'worker_lost',
-            ),
-            endedAt,
-            durationMs: candidate.startedAt ? endedAt.getTime() - candidate.startedAt.getTime() : 0,
-          },
-          $unset: {expiresAt: ''},
-        },
-        {returnDocument: 'after'},
-      )
-      if (!history) continue
-
-      const delivery = await this.getCollections().deliveries.findOne({_id: history.deliveryId})
+    const deliveryIds = reapedHistories.map(history => history.deliveryId)
+    const deliveries =
+      deliveryIds.length === 0
+        ? []
+        : await this.getCollections()
+            .deliveries.find({_id: {$in: deliveryIds}})
+            .toArray()
+    const deliveryById = new Map(deliveries.map(delivery => [delivery._id, delivery]))
+    for (const history of reapedHistories) {
+      const delivery = deliveryById.get(history.deliveryId)
       if (delivery?.status === 'pending') await this.afterAttemptError(delivery, history)
-      reaped++
+      else if (delivery) await this.applyTerminalRetention(delivery)
     }
-    return reaped
+
+    if (candidates.length === RECONCILIATION_BATCH_SIZE) this.nextReapAt = 0
+    else await this.scheduleNextReap(topics)
+    return reapedHistories.length
+  }
+
+  private async scheduleNextReap(topics: string[]) {
+    const next = await this.getCollections().history.findOne(
+      {
+        consumerGroup: this.options.consumerGroup,
+        topic: {$in: topics},
+        status: 'pending',
+        lockedUntil: {$exists: true},
+        lockToken: {$exists: true},
+      },
+      {sort: {lockedUntil: 1}, projection: {lockedUntil: 1}},
+    )
+    if (next?.lockedUntil) {
+      this.nextReapAt = Math.max(Date.now() + 1, next.lockedUntil.getTime())
+      return
+    }
+    const idleInterval = Math.max(
+      this.options.pollIntervalMs,
+      Math.min(MAX_REAPER_IDLE_INTERVAL_MS, Math.max(10, this.options.lockTimeoutMs / 3)),
+    )
+    this.nextReapAt = Date.now() + idleInterval
+  }
+
+  private async reconcileHistoryOutcomes(topics: string[], limit: number) {
+    if (limit <= 0) return 0
+    const collections = this.getCollections()
+    const histories = await collections.history
+      .find({
+        consumerGroup: this.options.consumerGroup,
+        topic: {$in: topics},
+        needsReconciliation: true,
+      })
+      .limit(limit)
+      .toArray()
+    if (histories.length === 0) return 0
+
+    const deliveries = await collections.deliveries
+      .find({_id: {$in: histories.map(history => history.deliveryId)}})
+      .toArray()
+    const deliveryById = new Map(deliveries.map(delivery => [delivery._id, delivery]))
+    for (const history of histories) {
+      const delivery = deliveryById.get(history.deliveryId)
+      if (!delivery) {
+        const expiresAt = getExpiresAt(
+          history.endedAt ?? history.createdAt,
+          this.options.historyRetentionMs,
+        )
+        await collections.history.updateOne(
+          {_id: history._id, needsReconciliation: true},
+          expiresAt
+            ? {$set: {expiresAt}, $unset: {needsReconciliation: ''}}
+            : {$unset: {needsReconciliation: ''}},
+        )
+        continue
+      }
+      if (delivery.status !== 'pending') await this.applyTerminalRetention(delivery)
+      else if (history.status === 'success') await this.finishDeliveryWithSuccess(delivery, history)
+      else if (history.status === 'error') await this.afterAttemptError(delivery, history)
+      await collections.history.updateOne(
+        {_id: history._id, needsReconciliation: true},
+        {$unset: {needsReconciliation: ''}},
+      )
+    }
+    return histories.length
+  }
+
+  private async reconcileDeliveryMarkers(topics: string[], limit: number) {
+    if (limit <= 0) return 0
+    const collections = this.getCollections()
+    const deliveries = await collections.deliveries
+      .find({
+        consumerGroup: this.options.consumerGroup,
+        topic: {$in: topics},
+        needsReconciliation: true,
+      })
+      .limit(limit)
+      .toArray()
+    if (deliveries.length === 0) return 0
+
+    const histories = await collections.history
+      .find({deliveryId: {$in: deliveries.map(delivery => delivery._id)}})
+      .sort({deliveryId: 1, attempt: -1})
+      .toArray()
+    const latestByDelivery = new Map<string, HistoryDocument>()
+    const successByDelivery = new Map<string, HistoryDocument>()
+    for (const history of histories) {
+      if (!latestByDelivery.has(history.deliveryId)) {
+        latestByDelivery.set(history.deliveryId, history)
+      }
+      if (history.status === 'success' && !successByDelivery.has(history.deliveryId)) {
+        successByDelivery.set(history.deliveryId, history)
+      }
+    }
+
+    for (const delivery of deliveries) {
+      if (delivery.status !== 'pending') {
+        await this.applyTerminalRetention(delivery)
+        continue
+      }
+      const successful = successByDelivery.get(delivery._id)
+      const latest = latestByDelivery.get(delivery._id)
+      if (successful) await this.finishDeliveryWithSuccess(delivery, successful)
+      else if (!latest) await this.ensureAttempt(delivery, 1, delivery.createdAt)
+      else if (latest.status === 'error') await this.afterAttemptError(delivery, latest)
+      await collections.deliveries.updateOne(
+        {_id: delivery._id, status: 'pending', needsReconciliation: true},
+        {$unset: {needsReconciliation: ''}},
+      )
+    }
+    return deliveries.length
   }
 
   private async reconcileDeliveries(topics: string[]) {
     if (topics.length === 0) return 0
-    const statuses: Array<DeliveryDocument['status']> =
-      this.options.historyRetentionMs === null ? ['pending'] : ['pending', 'success', 'error']
-    const selectedTopics = circularBatch(
+    const historyCount = await this.reconcileHistoryOutcomes(topics, RECONCILIATION_BATCH_SIZE)
+    const deliveryCount = await this.reconcileDeliveryMarkers(
       topics,
-      this.recoveryTopicOffset,
-      Math.max(1, Math.floor(RECONCILIATION_BATCH_SIZE / statuses.length)),
+      RECONCILIATION_BATCH_SIZE - historyCount,
     )
-    this.recoveryTopicOffset = (this.recoveryTopicOffset + selectedTopics.length) % topics.length
-    const perBranchLimit = Math.max(
-      1,
-      Math.floor(RECONCILIATION_BATCH_SIZE / (selectedTopics.length * statuses.length)),
-    )
-    const branches = selectedTopics.flatMap(topic =>
-      statuses.map(status => {
-        const key = `${topic}\0${status}`
-        const cursor = this.recoveryCursors.get(key)
-        const common = {
-          consumerGroup: this.options.consumerGroup,
-          topic,
-          status,
-          ...(status === 'pending' ? {} : {expiresAt: {$exists: false}}),
-        }
-        const match = cursor
-          ? {
-              $or: [
-                {...common, eventCreatedAt: {$gt: cursor.eventCreatedAt}},
-                {
-                  ...common,
-                  eventCreatedAt: cursor.eventCreatedAt,
-                  eventId: {$gt: cursor.eventId},
-                },
-              ],
-            }
-          : common
-        return {
-          key,
-          pipeline: [
-            {$match: match},
-            {$sort: {eventCreatedAt: 1, eventId: 1}},
-            {$limit: perBranchLimit},
-          ] satisfies Document[],
-        }
-      }),
-    )
-    const [first, ...remaining] = branches
-    const pipeline: Document[] = [...first.pipeline]
-    for (const branch of remaining) {
-      pipeline.push({
-        $unionWith: {
-          coll: this.getCollections().deliveries.collectionName,
-          pipeline: branch.pipeline,
-        },
-      })
-    }
-    const deliveries = (await this.getCollections()
-      .deliveries.aggregate(pipeline)
-      .toArray()) as DeliveryDocument[]
-    const latestByBranch = new Map<string, DeliveryDocument>()
-    for (const delivery of deliveries) {
-      latestByBranch.set(`${delivery.topic}\0${delivery.status}`, delivery)
-    }
-    for (const branch of branches) {
-      const latest = latestByBranch.get(branch.key)
-      if (latest) {
-        this.recoveryCursors.set(branch.key, {
-          eventCreatedAt: latest.eventCreatedAt,
-          eventId: latest.eventId,
-        })
-      } else if (this.recoveryCursors.has(branch.key)) {
-        this.recoveryCursors.delete(branch.key)
-      }
-    }
-
-    let reconciled = 0
-    for (const delivery of deliveries) {
-      if (delivery.status !== 'pending') {
-        await this.applyTerminalRetention(delivery)
-        reconciled++
-        continue
-      }
-
-      const successful = await this.getCollections().history.findOne(
-        {deliveryId: delivery._id, status: 'success'},
-        {sort: {attempt: 1}},
-      )
-      if (successful) {
-        await this.finishDeliveryWithSuccess(delivery, successful)
-        reconciled++
-        continue
-      }
-
-      const latest = await this.getCollections().history.findOne(
-        {deliveryId: delivery._id},
-        {sort: {attempt: -1}},
-      )
-      if (!latest) {
-        await this.ensureAttempt(delivery, 1, delivery.createdAt)
-        reconciled++
-        continue
-      }
-      if (latest.status === 'error') {
-        await this.afterAttemptError(delivery, latest)
-        reconciled++
-      }
-    }
+    const reconciled = historyCount + deliveryCount
+    this.nextReconciliationAt =
+      reconciled === RECONCILIATION_BATCH_SIZE ? 0 : Date.now() + RECONCILIATION_INTERVAL_MS
     return reconciled
   }
+
+  /*
+   * Cross-collection writes set needsReconciliation on their durable first write and clear it
+   * only after the dependent write succeeds. Recovery therefore reads only the tiny partial
+   * indexes instead of walking every healthy delivery while a backlog is draining.
+   */
 
   private async acquireOrderedLease(
     local: LocalSubscription,

--- a/packages/pulse/src/indexes.ts
+++ b/packages/pulse/src/indexes.ts
@@ -20,6 +20,7 @@ interface ExpectedIndex {
   key: Record<string, 1 | -1>
   unique?: boolean
   expireAfterSeconds?: number
+  partialFilterExpression?: Record<string, unknown>
 }
 
 const eventsIndexes: ExpectedIndex[] = [
@@ -77,6 +78,11 @@ const deliveriesIndexes: ExpectedIndex[] = [
     key: {status: 1, eventCreatedAt: 1, eventId: 1},
   },
   {
+    name: 'pulse_deliveries_reconciliation',
+    key: {consumerGroup: 1, topic: 1},
+    partialFilterExpression: {needsReconciliation: true},
+  },
+  {
     name: 'pulse_deliveries_expires_at_ttl',
     key: {expiresAt: 1},
     expireAfterSeconds: 0,
@@ -108,6 +114,11 @@ const historyIndexes: ExpectedIndex[] = [
   {
     name: 'pulse_history_pending_acquisition',
     key: {consumerGroup: 1, topic: 1, status: 1, nextAttemptAt: 1, createdAt: 1},
+  },
+  {
+    name: 'pulse_history_reconciliation',
+    key: {consumerGroup: 1, topic: 1},
+    partialFilterExpression: {needsReconciliation: true},
   },
   {
     name: 'pulse_history_expires_at_ttl',
@@ -158,13 +169,14 @@ function validateIndex(
   const keysMatch = JSON.stringify(actualKey) === JSON.stringify(expectedKey)
   const uniqueMatches = Boolean(actual.unique) === Boolean(expected.unique)
   const ttlMatches = actual.expireAfterSeconds === expected.expireAfterSeconds
-  const hasDefaultSemantics =
-    !actual.sparse &&
-    !actual.hidden &&
-    actual.partialFilterExpression === undefined &&
-    actual.collation === undefined
+  const partialFilterMatches =
+    JSON.stringify(actual.partialFilterExpression) ===
+    JSON.stringify(expected.partialFilterExpression)
+  const hasDefaultSemantics = !actual.sparse && !actual.hidden && actual.collation === undefined
 
-  if (keysMatch && uniqueMatches && ttlMatches && hasDefaultSemantics) return
+  if (keysMatch && uniqueMatches && ttlMatches && partialFilterMatches && hasDefaultSemantics) {
+    return
+  }
 
   throw new PulseIndexError(
     `Pulse index "${expected.name}" on "${collectionName}" is incompatible. ` +
@@ -178,6 +190,9 @@ function toIndexDescription(index: ExpectedIndex): IndexDescription {
     ...(index.unique ? {unique: true} : {}),
     ...(index.expireAfterSeconds !== undefined
       ? {expireAfterSeconds: index.expireAfterSeconds}
+      : {}),
+    ...(index.partialFilterExpression
+      ? {partialFilterExpression: index.partialFilterExpression}
       : {}),
   }
 

--- a/packages/pulse/src/types.ts
+++ b/packages/pulse/src/types.ts
@@ -45,6 +45,7 @@ export interface PulseReceivedEvent<TTopic extends string = string, TData = unkn
 }
 
 export interface PulseSubscribeOptions {
+  /** Defaults to false. */
   ordered?: boolean
   offsetReset?: PulseOffsetReset
   delivery?: PulseDeliveryMode

--- a/packages/pulse/src/types.ts
+++ b/packages/pulse/src/types.ts
@@ -187,6 +187,8 @@ export interface DeliveryDocument extends Document {
   expiresAt?: Date
   finalAttempt?: number
   error?: PulseHistoryError
+  /** Internal crash-recovery marker. Present only while a cross-collection write is incomplete. */
+  needsReconciliation?: true
 }
 
 export interface HistoryDocument extends Document {
@@ -209,6 +211,8 @@ export interface HistoryDocument extends Document {
   durationMs?: number
   expiresAt?: Date
   error?: PulseHistoryError
+  /** Internal crash-recovery marker. Present only while its delivery still needs an update. */
+  needsReconciliation?: true
 }
 
 export interface ResolvedSubscribeOptions {

--- a/packages/pulse/src/types.ts
+++ b/packages/pulse/src/types.ts
@@ -47,6 +47,11 @@ export interface PulseReceivedEvent<TTopic extends string = string, TData = unkn
 export interface PulseSubscribeOptions {
   /** Defaults to false. */
   ordered?: boolean
+  /**
+   * Integer version for persisted subscription settings. Higher versions win.
+   * Legacy and omitted versions are treated as zero.
+   */
+  configVersion?: number
   offsetReset?: PulseOffsetReset
   delivery?: PulseDeliveryMode
   maxRetries?: number
@@ -63,6 +68,7 @@ export interface PulseSubscriptionInfo {
   id: string
   topic: string
   consumerGroup: string
+  configVersion: number
   ordered: boolean
   offsetReset: PulseOffsetReset
   delivery: PulseDeliveryMode
@@ -144,6 +150,7 @@ export interface SubscriptionDocument extends Document {
   _id: string
   consumerGroup: string
   topic: string
+  configVersion?: number
   ordered: boolean
   offsetReset: PulseOffsetReset
   delivery: PulseDeliveryMode
@@ -205,6 +212,7 @@ export interface HistoryDocument extends Document {
 }
 
 export interface ResolvedSubscribeOptions {
+  configVersion: number
   ordered: boolean
   offsetReset: PulseOffsetReset
   delivery: PulseDeliveryMode
@@ -217,6 +225,7 @@ export interface ResolvedSubscribeOptions {
 export interface LocalSubscription {
   document: SubscriptionDocument
   options: ResolvedSubscribeOptions
+  configuredMaxConcurrency: number
   handler: PulseEventHandler<string, unknown>
   running: number
   unsubscribed: boolean


### PR DESCRIPTION
## Summary

- default new Pulse subscriptions to unordered delivery
- expose ordered and configVersion per Echoes event listener
- persist configVersion with each consumerGroup + topic subscription
- atomically apply higher versions, prevent downgrades, and reject conflicting settings at the same version
- preserve legacy ordering when ordered is omitted on an existing subscription
- add a documentation post explaining defaults, upgrades, and deploy transitions

## Version semantics

- legacy and omitted configVersion values are version 0
- higher versions replace lower versions atomically
- lower-version replicas adopt the persisted winner
- the same version with different durable settings fails fast
- callbacks already claimed finish normally while new work converges on the winning version

## Testing

- Pulse: 69 tests passed
- Echoes: 10 tests passed
- bun run build in packages/pulse
- bun run build in packages/echoes